### PR TITLE
Adding support to display the second non-xml data view - tree view.

### DIFF
--- a/app/controllers/dams_assembled_collections_controller.rb
+++ b/app/controllers/dams_assembled_collections_controller.rb
@@ -303,7 +303,8 @@ end
   end
 
   def data_view
-      data = get_html_data ( params[:id] )
+  	  controller_path = dams_collection_path params[:id]
+      data = get_html_data params, controller_path
       render :text => data
   end
 

--- a/app/controllers/dams_collections_controller.rb
+++ b/app/controllers/dams_collections_controller.rb
@@ -63,7 +63,8 @@ class DamsCollectionsController < ApplicationController
   end
   
   def data_view
-      data = get_html_data ( params[:id] )
+      controller_path = dams_collection_path params[:id]
+      data = get_html_data params, controller_path
       render :text => data
   end
   

--- a/app/controllers/dams_objects_controller.rb
+++ b/app/controllers/dams_objects_controller.rb
@@ -518,7 +518,8 @@ class DamsObjectsController < ApplicationController
   end
   
   def data_view
-  	data = get_html_data ( params[:id] )
+  	controller_path = dams_collection_path params[:id]
+    data = get_html_data params, controller_path
     render :text => data
   end 
   

--- a/app/controllers/dams_provenance_collection_parts_controller.rb
+++ b/app/controllers/dams_provenance_collection_parts_controller.rb
@@ -301,7 +301,8 @@ def edit
    end
    
   def data_view
-      data = get_html_data ( params[:id] )
+      controller_path = dams_collection_path params[:id]
+      data = get_html_data params, controller_path
       render :text => data
   end
 

--- a/app/controllers/dams_provenance_collections_controller.rb
+++ b/app/controllers/dams_provenance_collections_controller.rb
@@ -296,7 +296,8 @@ class DamsProvenanceCollectionsController < ApplicationController
   end
 
   def data_view
-      data = get_html_data ( params[:id] )
+      controller_path = dams_collection_path params[:id]
+      data = get_html_data params, controller_path
       render :text => data
   end 
 

--- a/lib/dams/controller_helper.rb
+++ b/lib/dams/controller_helper.rb
@@ -637,10 +637,12 @@ module Dams
       end
     end
     
-    def get_html_data ( pid )
+    def get_html_data ( params, controller_path )
        baseurl = ActiveFedora.fedora_config.credentials[:url]
        baseurl = baseurl.gsub(/\/fedora$/,'')
-       viewerUrl = "#{baseurl}/api/objects/#{pid}/transform?recursive=true&xsl=review.xsl&baseurl=" + URI.encode(baseurl)
+       xsl = (params[:xsl].nil? || params[:xsl].empty?)?'review.xsl':params[:xsl]
+       controller = (controller_path.nil? || controller_path.empty?)?'':'&controller=' + URI.encode(controller_path)
+       viewerUrl = "#{baseurl}/api/objects/#{params[:id]}/transform?recursive=true&xsl=#{xsl}&baseurl=" + URI.encode(baseurl) + controller
        uri = URI(viewerUrl)
        res = Net::HTTP.get_response(uri)
        res.body


### PR DESCRIPTION
https://lib-jira.ucsd.edu:8443/browse/DAMSKEY-464

Esme, there are two style sheets in dams repo that are used for the data view tool: review.xsl and review-tree.xsl. Could you add them to the damsrepo-tomcat snapshot? Otherwise the related test may failed. Thanks.
