### PR TITLE
Simplify DAMS Resource #can's

### DIFF
--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -110,6 +110,8 @@ class Ability
   end
 
   def can_create_dams_resource?(obj)
+    return true if user_groups.include? Rails.configuration.super_role
+
     return false if (user_groups & Rails.configuration.curator_groups).empty?
 
     unit = obj.instance_of?(DamsObject) ? obj.units : obj.damsMetadata.load_unit(obj.damsMetadata.unit)
@@ -117,7 +119,7 @@ class Ability
     return false if unit.nil? || unit.group.blank?
 
     unit_group = unit.group.first
-    result = user_groups.include?(Rails.configuration.super_role) || user_groups.include?(unit_group)
+    result = user_groups.include?(unit_group)
 
     logger.debug("[CANCAN] #{obj.class} creation decision: #{result}: #{unit_group}")
     result


### PR DESCRIPTION
@escowles This came up while I was doing a brief demo of the dams auth code last week, and I realized how identical these #can create methods were for the DAMS Resource models. Since I had this done locally, I figured I'd setup a PR to get your thoughts.
