### PR TITLE
Passing fq parameters through to solr (DHH-622)

### DIFF
--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -40,6 +40,9 @@ class CatalogController < ApplicationController
           name = lookup_unit_name( f.gsub( /.*unit_code_tesim:/,"" ) )
           params[:f] = {} unless params[:f]
           params[:f][:unit_sim] = [name]
+        else
+          # passthrough for other params
+          solr_parameters[:fq] << f
         end
       end
     end
@@ -251,7 +254,7 @@ class CatalogController < ApplicationController
       	 end
         end
       end
-           
+
       if params['xf'] != nil
         params['f'] = JSON.parse params.delete('xf').gsub('=>', ':')
       end

--- a/spec/features/catalog_spec.rb
+++ b/spec/features/catalog_spec.rb
@@ -157,4 +157,24 @@ feature 'Visitor wants to search with single or double quote' do
     expect(page).to have_selector('h3', :text => 'Sample Image Component') 
              
   end
+
+  feature 'Visitor wants to limit search with a provided Solr filter query' do
+    before do
+      @public = DamsCopyright.create(status: "Public domain")
+      @obj1 = DamsObject.create(titleValue: "Query Sample 1", copyrightURI: @public.pid)
+      solr_index @obj1.pid
+      @obj2 = DamsObject.create(titleValue: "Query Sample 2", copyrightURI: @public.pid)
+      solr_index @obj2.pid
+    end
+    after do
+      @obj1.delete
+      @obj2.delete
+    end
+
+    scenario 'search with filter query' do
+      visit catalog_index_path( {q: 'query sample', fq: ['title_tesim:1']} )
+      expect(page).to have_selector('h3', text: 'Query Sample 1')
+      expect(page).not_to have_selector('h3', text: 'Query Sample 2')
+    end
+  end
 end


### PR DESCRIPTION
Allows passing arbitrary fq parameters to solr using the fq[] parameter.
Fixes: https://lib-jira.ucsd.edu:8443/browse/DHH-622