### PR TITLE
Hiding counter param in the object view url. (DHH-635)

### DIFF
--- a/app/controllers/dams_resource_controller.rb
+++ b/app/controllers/dams_resource_controller.rb
@@ -10,16 +10,18 @@ class DamsResourceController < ApplicationController
   # solr actions ###############################################################
   ##############################################################################
   def show
-    session[:search][:counter] = params[:counter] if params[:counter]
-
-    search_results = request.env["HTTP_REFERER"]	
-    session[:search_results] = search_results if (!search_results.nil? && search_results.include?("search"))
-   
-    if(params[:counter] || (!search_results.nil? && search_results.include?("search")) )
-      # import solr config from catalog_controller and setup next/prev docs
-      @blacklight_config = CatalogController.blacklight_config
-      setup_next_and_previous_documents
-    end 
+	search_results = request.env["HTTP_REFERER"]
+    session[:search_results] = search_results if (!search_results.nil? && search_results.include?("search"))	
+     
+    if(params[:counter])
+      session[:search][:counter] = params[:counter]
+      redirect_to dams_object_path(params[:id])
+      return
+    end   
+  
+    # import solr config from catalog_controller and setup next/prev docs
+    @blacklight_config = CatalogController.blacklight_config
+	setup_next_and_previous_documents
    
     # get metadata from solr
     @document = get_single_doc_via_search(1, {:q => "id:#{params[:id]}"} )

--- a/app/controllers/dams_resource_controller.rb
+++ b/app/controllers/dams_resource_controller.rb
@@ -10,8 +10,8 @@ class DamsResourceController < ApplicationController
   # solr actions ###############################################################
   ##############################################################################
   def show
-	search_results = request.env["HTTP_REFERER"]
-    session[:search_results] = search_results if (!search_results.nil? && search_results.include?("search"))	
+    search_results = request.env["HTTP_REFERER"]
+    session[:search_results] = search_results if (!search_results.nil? && search_results.include?("search"))
      
     if(params[:counter])
       session[:search][:counter] = params[:counter]
@@ -21,7 +21,7 @@ class DamsResourceController < ApplicationController
   
     # import solr config from catalog_controller and setup next/prev docs
     @blacklight_config = CatalogController.blacklight_config
-	setup_next_and_previous_documents
+    setup_next_and_previous_documents
    
     # get metadata from solr
     @document = get_single_doc_via_search(1, {:q => "id:#{params[:id]}"} )

--- a/spec/controllers/dams_objects_controller_spec.rb
+++ b/spec/controllers/dams_objects_controller_spec.rb
@@ -5,11 +5,13 @@ require 'json'
 describe DamsObjectsController do
   before(:all) do
     @unit = DamsUnit.create name: "Test Unit", description: "Test Description", code: "tu", uri: "http://example.com/" 
-    @copy = DamsCopyright.create 
+    @copy = DamsCopyright.create status: 'Public domain'
     @obj = DamsObject.create titleValue: "Spellcheck Test", subtitle: "Subtitle Test", beginDate: "2013", unitURI: @unit.pid, copyrightURI: @copy.pid
+    @obj2 = DamsObject.create titleValue: "Test Record #2", unitURI: @unit.pid, copyrightURI: @copy.pid
   end
   after(:all) do
     @obj.delete
+    @obj2.delete
     @copy.delete
     @unit.delete
   end
@@ -41,6 +43,16 @@ describe DamsObjectsController do
       sign_in User.create! ({:provider => 'developer'})
       get :ezid, { id: @obj.pid }
       flash[:alert].should include "Minting DOI failed"
+    end
+  end
+
+  describe "search results counter" do
+    it "should redirect requests with a counter param" do
+      ref = 'http://test.com/search?q=test'
+      @request.env['HTTP_REFERER'] = ref
+      get :show, { id: @obj.pid, counter: 1 }
+      response.should redirect_to dams_object_path @obj.pid
+      expect(session[:search_results]).to eq(ref)
     end
   end
 end

--- a/spec/features/catalog_spec.rb
+++ b/spec/features/catalog_spec.rb
@@ -109,6 +109,21 @@ feature 'Visitor wants to search' do
     idx2 = page.body.index('ZZZ Test Subject 2')
     idx1.should <( idx2 )
   end  
+
+  scenario 'search results paging' do
+    visit catalog_index_path( {'q' => 'sample', 'sort' => 'title_ssi asc'} )
+    expect(page).to have_selector('h3', :text => 'Sample Object 1')
+    expect(page).to have_selector('h3', :text => 'Sample Object 2')
+    expect(page).to have_selector('h3', :text => 'Sample Object 3')
+
+    expect(page).to have_selector('div', :text => 'Results 1 - 3 of 3')
+    click_on "Sample Object 2"
+    expect(page).to have_link('Previous', href: dams_object_path(@obj1, counter: 1) )
+    expect(page).to have_link('Next', href: dams_object_path(@obj3, counter: 3) )
+
+    click_on "Next"
+    expect(page).to have_link('Previous', href: dams_object_path(@obj2, counter: 2) )
+  end
 end
 
 feature "Search and browse linked names and subjects" do

--- a/spec/features/catalog_spec.rb
+++ b/spec/features/catalog_spec.rb
@@ -116,13 +116,20 @@ feature 'Visitor wants to search' do
     expect(page).to have_selector('h3', :text => 'Sample Object 2')
     expect(page).to have_selector('h3', :text => 'Sample Object 3')
 
-    expect(page).to have_selector('div', :text => 'Results 1 - 3 of 3')
+    # viewing item from search results should have pager
     click_on "Sample Object 2"
+    expect(page).to have_selector('div', :text => 'Previous 2 of 3 results Next')
     expect(page).to have_link('Previous', href: dams_object_path(@obj1, counter: 1) )
     expect(page).to have_link('Next', href: dams_object_path(@obj3, counter: 3) )
 
+    # pager should remain when paging through results
     click_on "Next"
     expect(page).to have_link('Previous', href: dams_object_path(@obj2, counter: 2) )
+    expect(page).to have_selector('div', :text => 'Previous 3 of 3 results')
+
+    # should not have pager on direct links
+    visit dams_object_path @obj1
+    expect(page).to_not have_selector('div', :text => 'Previous 3 of 3 results')
   end
 end
 

--- a/spec/features/dams_object_spec.rb
+++ b/spec/features/dams_object_spec.rb
@@ -182,6 +182,15 @@ feature 'Visitor wants to click the direct object link when the referrer is not 
   end
 end
 
+feature 'Visitor wants to click the object link and does not want to see the counter parameter in the url' do
+  
+  scenario "is on the main page" do
+    visit catalog_index_path( {:q => 'sample'} )
+    click_link "Sample Image Component"
+    URI.parse(current_url).request_uri.should == "/object/bd3379993m"
+  end
+end
+
 feature 'Format link(s) need to be scoped to the collection level ' do
   
   scenario "is on the object view page" do

--- a/spec/features/dams_object_spec.rb
+++ b/spec/features/dams_object_spec.rb
@@ -185,6 +185,7 @@ end
 feature 'Visitor wants to click the object link and does not want to see the counter parameter in the url' do
   
   scenario "is on the main page" do
+    pending "working object metadata updates"
     visit catalog_index_path( {:q => 'sample'} )
     click_link "Sample Image Component"
     URI.parse(current_url).request_uri.should == "/object/bd3379993m"


### PR DESCRIPTION
Based on #80 -- working around semi-broken object metadata updates
Adding controller tests and feature tests that use test-created sample records
Adding feature test to make sure pager isn't displayed on direct-linked pages