### PR TITLE
Changed to use the #reject method instead of the bang #reject!.

### DIFF
--- a/app/helpers/dams_objects_helper.rb
+++ b/app/helpers/dams_objects_helper.rb
@@ -812,7 +812,7 @@ def display_node(index)
 
   def listComponents (component_map)
     components = component_map.nil? ? [] : component_map.first.dup.gsub!(':', ',').gsub!(/[\[\]{}"]/, '').split(',')
-    components.reject! { |c| c.blank? }.map! { |i| i.to_i } 
+    components.reject { |c| c.blank? }.map! { |i| i.to_i } 
   end
 
   #-------------------------------


### PR DESCRIPTION
See https://lib-jira.ucsd.edu:8443/browse/DHH-389.
The bang #reject! method may return nil unexpectedly when there is no matched for rejecting.