### PR TITLE
Removed the codes for the RDF edit form, changed the Edit button to link to damsmanager. DM-112

### DIFF
--- a/app/controllers/dams_objects_controller.rb
+++ b/app/controllers/dams_objects_controller.rb
@@ -37,49 +37,4 @@ class DamsObjectsController < DamsResourceController
 
     render layout: 'minimal'
   end
-
-  def edit
-
-    # get metadata from solr
-    @document = get_single_doc_via_search(1, {:q => "id:#{params[:id]}"} )
-
-    # enforce access controls
-    authorize! :edit, @document
-
-    @format = params[:format].blank? ? 'xml' : params[:format]
-    @data = get_data false, @format
-    @data.to_s.force_encoding("UTF-8")
-    @edit_form = DamsObject.find(pid: params[:id])
-  end
-
-  def update
-    # get metadata from solr
-    @document = get_single_doc_via_search(1, {:q => "id:#{params[:id]}"} )
-
-    # enforce access controls
-    authorize! :edit, @document
-
-    begin
-        @damsObj = DamsObject.find(pid: params[:id]).first
-        @damsObj.damsMetadata.content = params[:dams_object]['damsMetadata']
-
-        if @damsObj.save!
-          flash[:notice] = 'Update Successfully!'
-          redirect_to dams_object_path
-          return
-        else
-          flash[:alert] = "Failed to update record: " + @damsObj.errors.full_messages.map { |s| s.to_s }.join(", ")
-        end
-    rescue Exception => e
-      err = e.to_s
-      if (!err.downcase.index('400 bad request').nil?)
-        flash[:error] = 'Error status code ' + err + ': ' + 'Invalid RDF Input.'
-      else
-        flash[:error] = "Failed to update record: " + err
-      end 
-    end
-
-    redirect_to edit_path
-  end
-
 end

--- a/app/helpers/dams_objects_helper.rb
+++ b/app/helpers/dams_objects_helper.rb
@@ -899,4 +899,8 @@ def display_node(index)
     "#{baseurl}/api/objects/#{pid}/transform?recursive=true&xsl=normalize.xsl"
   end
 
+  def rdf_edit_url (pid)
+     proxy_url = ActiveFedora.fedora_config.credentials[:proxy]
+     "#{proxy_url.nil? ? '' : proxy_url}/damsmanager/rdfImport.do?ark=#{pid}"
+  end
 end

--- a/app/views/dams_objects/_edit_button.html.erb
+++ b/app/views/dams_objects/_edit_button.html.erb
@@ -1,4 +1,4 @@
-<a class="btn btn-small btn-primary" href="<%= edit_path @document['id']%>">
+<a class="btn btn-small btn-primary" target="edit-form" href="<%= rdf_edit_url (@document['id'])%>">
   <i class="icon-edit icon-white"></i>Edit
 </a>
 

--- a/spec/controllers/dams_objects_controller_spec.rb
+++ b/spec/controllers/dams_objects_controller_spec.rb
@@ -71,25 +71,4 @@ describe DamsObjectsController do
       expect(session[:search_results]).to be_nil
     end
   end
-
-  describe "edit" do
-    it "should redirect edit page" do
-      sign_in User.create! ({:provider => 'developer'})
-
-      get :edit, { id: @obj.pid }
-      expect(response.status).to eq( 200 )
-    end
-    it "should update object" do
-      sign_in User.create({:provider => 'developer'})
-      put :update, { id: @obj.pid, format: 'xml', dams_object: {"damsMetadata" => @obj.damsMetadata.content} }
-      flash[:notice].should include "Update Successfully!"
-    end
-    it "should get 400 Bad Request error with invalid RDF" do
-      sign_in User.create! ({:provider => 'developer'})
-      content = @obj.damsMetadata.content.gsub(':title', ':titleN')
-      put :update, { id: @obj.pid, format: 'xml', dams_object: {"damsMetadata" => content} }
-      flash[:error].should_not be_nil
-      flash[:error].should include "400 Bad Request"
-    end
-  end
 end

--- a/spec/features/dams_object_spec.rb
+++ b/spec/features/dams_object_spec.rb
@@ -64,56 +64,10 @@ feature 'Visitor want to look at objects' do
       expect(page.status_code).to eq 200
       expect(response_headers['Content-Type']).to include 'application/rdf+xml'
     end
-    it "should load the Edit Form" do
+    it "should contain damsmanger url for RDF Edit" do
       sign_in_developer
       visit dams_object_path @o
-      click_on 'Edit'
-      expect(page.status_code).to eq 200
-      expect(page).to have_selector('h3',:text=>'Edit The Test Title')
-    end
-    it "should get 400 Bad Request message for submitting invalid RDF" do
-      sign_in_developer
-      visit edit_path @o
-      expect(page.status_code).to eq 200
-      expect(page).to have_selector('h3',:text=>'Edit The Test Title')
-      content = @o.damsMetadata.content.gsub(':Title', ':TitleNon')
-      first("textarea[name='dams_object[damsMetadata]']").set(content)
-      click_on 'Submit'
-      expect(page.status_code).to eq 200
-      expect(page).to have_content('400 Bad Request')
-    end
-    it "should be able to update object record" do
-      sign_in_developer
-      visit edit_path @o
-      expect(page.status_code).to eq 200
-      expect(page).to have_selector('h3',:text=>'Edit The Test Title')
-      newTitle = @o.damsMetadata.content.gsub! 'Test Title', 'Edited Test Title'
-      first("textarea[name='dams_object[damsMetadata]']").set(newTitle)
-      click_on 'Submit'
-      expect(page.status_code).to eq 200
-      expect(page).to have_selector('h1',:text=>'The Edited Test Title')
-    end
-  end
-
-  describe "RDF Edit form" do
-    before(:all) do
-      @o = DamsObject.create titleValue: 'The Test Title - Carta Abierta al Gobierno de la Concertación',
-               copyright_attributes: [{status: 'Public domain'}]
-      solr_index @o.pid
-    end
-    after(:all) do
-      @o.delete
-    end
-    it "should be able to load and edit record with special characters and diacritic" do
-      sign_in_developer
-      visit edit_path @o
-      expect(page.status_code).to eq 200
-      expect(page).to have_selector('h3',:text=>"The Test Title - Carta Abierta al Gobierno de la Concertación")
-      newTitle = @o.damsMetadata.content.gsub! 'The Test Title', "The Editor's New Title"
-      first("textarea[name='dams_object[damsMetadata]']").set(newTitle)
-      click_on 'Submit'
-      expect(page.status_code).to eq 200
-      expect(page).to have_selector('h1',:text=>"The Editor's New Title - Carta Abierta al Gobierno de la Concertación")
+      expect(page).to have_xpath "//a[contains(@href,'/damsmanager/rdfImport.do?ark=#{@o.pid}')]"
     end
   end
 


### PR DESCRIPTION
Remove the the RDF edit form implementation and update the Edit button in the object page to point to damsmanager. Please update private-config for the proxy URL parameter for the edit link in local environment.
https://lib-jira.ucsd.edu:8443/browse/DM-112