### PR TITLE
Added curator id to the file urls for dams statistics. DM-146

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -187,5 +187,13 @@ module ApplicationHelper
       return JSON.parse(datum)['name']
     end
   end
-    
+
+  def to_stats_path (path)
+    if !path.blank? && !session[:user_id].blank?
+      path += path.index('?').nil? ? '?' : '&'
+      path + 'access=curator'
+    else
+      path
+    end
+  end
 end 

--- a/app/helpers/catalog_helper.rb
+++ b/app/helpers/catalog_helper.rb
@@ -128,6 +128,8 @@ module CatalogHelper
       url = file_path parts[0], "_" + parts[1].gsub("/","_")
     end
 
+    url = to_stats_path url
+
     image_tag( url, :alt => "", :class => 'dams-search-thumbnail') unless url.blank?
   end
 

--- a/app/views/catalog/_document_thumbnail.html.erb
+++ b/app/views/catalog/_document_thumbnail.html.erb
@@ -4,6 +4,8 @@
     else
       url = dams_object_path(document, :counter => opts[:counter] )
     end
+
+    url = to_stats_path url
     
     restrictedNotice = grabRestrictedText(document['otherNote_json_tesim'])
 %>

--- a/app/views/dams_objects/_complex_object_viewer.html.erb
+++ b/app/views/dams_objects/_complex_object_viewer.html.erb
@@ -45,6 +45,10 @@
 	        else
 	          download_file_path = ''
 	        end
+
+	        display_file_path = to_stats_path display_file_path
+	        service_file_path = to_stats_path service_file_path
+	        download_file_path = to_stats_path download_file_path
 		%>
 
 		<div id="component-<%= i %>" class="component <%= firstComponent %>" <%= loadFirstComponent %>>

--- a/app/views/dams_objects/_simple_object_viewer.html.erb
+++ b/app/views/dams_objects/_simple_object_viewer.html.erb
@@ -8,6 +8,15 @@
 	    </div>
     </div>
   <% end %>
+  <%
+	
+	display_file_path = to_stats_path display_file_path
+	service_file_path = to_stats_path service_file_path
+	pdf_file_path = to_stats_path pdf_file_path
+	source_file_path = to_stats_path source_file_path
+	download_derivative_path = to_stats_path download_derivative_path
+	download_file_path = to_stats_path download_file_path
+  %>
 
 	<div class="simple-object">
 		<% case fileType %>

--- a/spec/features/dams_object_spec.rb
+++ b/spec/features/dams_object_spec.rb
@@ -691,7 +691,7 @@ describe "Curator complex object viewer" do
     sign_in_developer
     visit dams_object_path(@damsComplexObj8.pid)
     expect(page).to have_content "Component 1 Title"
-    expect(page).to have_link('', href:"/object/xx080808xx/_1_1.tif/download")
+    expect(page).to have_link('', href:"/object/xx080808xx/_1_1.tif/download?access=curator")
   end
   it "should have the label 'Components' in the component header" do
     sign_in_developer

--- a/spec/features/file_spec.rb
+++ b/spec/features/file_spec.rb
@@ -46,7 +46,7 @@ feature "Derivative download" do
     sign_in_developer
     visit dams_object_path @obj1
     expect(page).to have_selector('h1', text: 'JPEG Test')
-    expect(page).to have_link('', href:"/object/#{@obj1.pid}/_1.jpg/download")
+    expect(page).to have_link('', href:"/object/#{@obj1.pid}/_1.jpg/download?access=curator")
   end
   scenario 'anonymous should not see download link for audio file' do
     visit dams_object_path @obj2
@@ -57,7 +57,7 @@ feature "Derivative download" do
     sign_in_developer
     visit dams_object_path @obj2
     expect(page).to have_selector('h1', text: 'MP3 Test')
-    expect(page).to have_link('', href:"/object/#{@obj2.pid}/_1.mp3/download")
+    expect(page).to have_link('', href:"/object/#{@obj2.pid}/_1.mp3/download?access=curator")
   end
   scenario "Anonymous shouldn't be able to access restricted object files" do
     visit file_path( @obj3, '_1.txt' )
@@ -89,8 +89,8 @@ describe "Download more than one master file" do
     
     sign_in_developer
     visit dams_object_path(@newspaper.pid)
-    expect(page).to have_link('', href:"/object/xx21171293/_1.pdf/download")
-    expect(page).to have_link('', href:"/object/xx21171293/_2.tgz/download")    
+    expect(page).to have_link('', href:"/object/xx21171293/_1.pdf/download?access=curator")
+    expect(page).to have_link('', href:"/object/xx21171293/_2.tgz/download?access=curator")    
   end
 end
 
@@ -111,6 +111,6 @@ describe "Download file in complex object" do
   it "should show a download button" do
     sign_in_developer
     visit dams_object_path @complexObj.pid
-    expect(page).to have_link('', href:"/object/#{@complexObj.pid}/_1_2.jpg/download")  
+    expect(page).to have_link('', href:"/object/#{@complexObj.pid}/_1_2.jpg/download?access=curator")  
   end
 end


### PR DESCRIPTION
Added curator id to the file path and object url to track curator access for RDCP statistics, https://lib-jira.ucsd.edu:8443/browse/DM-146.