### PR TITLE
separate dev and test data

### DIFF
--- a/config/database.yml
+++ b/config/database.yml
@@ -8,10 +8,10 @@ default: &default
   pool: 5
   timeout: 5000
   database: db/development.sqlite3
-  
+
 development:
   <<: *default
-  
+
 pontos:
   <<: *default
   adapter: postgresql
@@ -19,7 +19,7 @@ pontos:
   host: <%= ENV.fetch('APPS_DHH_PONTOS_DB_HOST') {'default'}%>
   username: <%= ENV.fetch('APPS_DHH_PONTOS_DB_USER') {'default'}%>
   password: <%= ENV.fetch('APPS_DHH_PONTOS_DB_PASS') {'default'}%>
-  
+
 gimili:
   <<: *default
   adapter: postgresql
@@ -27,7 +27,7 @@ gimili:
   host: <%= ENV.fetch('APPS_DHH_GIMILI_DB_HOST') {'default'}%>
   username: <%= ENV.fetch('APPS_DHH_GIMILI_DB_USER') {'default'}%>
   password: <%= ENV.fetch('APPS_DHH_GIMILI_DB_PASS') {'default'}%>
-  
+
 staging:
   <<: *default
   adapter: postgresql
@@ -52,6 +52,7 @@ demo:
 # Do not set this db to the same as development or production.
 test:
   <<: *default
+  database: db/test.sqlite3
 
 production:
   <<: *default


### PR DESCRIPTION
@ucsdlib/developers - I think the reason why the development data that you're loading in dams-vagrant is getting wiped out after a run of the test suite is that the development and test database configurations were using the same database `db/development.sqlite3`

This change add an explicit test database. Can a few of you please:

- Pull down this branch into your dams-vagrant instance
- Load some sample records
- Run the test suite
- Check to see if your sample records are still available in the dev database