### PR TITLE
Fixes #243 -- Removed custom "AddThis" CSS

### DIFF
--- a/app/assets/stylesheets/custom-object-viewer.css.scss
+++ b/app/assets/stylesheets/custom-object-viewer.css.scss
@@ -153,17 +153,6 @@ $complexFile: #AC6F2B !default;
 .addthis_sharing_toolbox
 {
   float:right;
-  #atstbx
-  {
-    .at4-icon.aticon-compact, .at4-icon.aticon-more, .at4-icon.aticon-expanded, .at4-icon.aticon-addthis
-    {
-      background: url("../images/sharing-icon.png") no-repeat scroll center center rgba(0, 0, 0, 0) !important;
-      background-size: 15px 15px !important;
-      width: 15px !important;
-      height: 15px !important;
-    }
-    a.at-svc-compact{background-color: transparent !important;}
-  }
 }
 
 // Sidebar


### PR DESCRIPTION
Removed the custom CSS we had in place to override the look of the
previous version of the AddThis share button we were using on the
Collections and Objects views.