### PR TITLE
Fixes marking the title link in the search result page for RDCP curator stats. #110

### DIFF
--- a/app/helpers/catalog_helper.rb
+++ b/app/helpers/catalog_helper.rb
@@ -27,6 +27,7 @@ module CatalogHelper
       url = dams_object_path(doc, :counter => opts[:counter] )
     end
 
+    url = to_stats_path url
     link_to label, url, { :'data-counter' => opts[:counter] }.merge(opts.reject { |k,v| [:label, :counter, :force_label, :results_view].include? k  })
 
   end

--- a/spec/features/catalog_spec.rb
+++ b/spec/features/catalog_spec.rb
@@ -150,6 +150,7 @@ feature 'Visitor wants to search' do
   	sign_in_developer
     visit catalog_index_path( {:q => '"QE8iWjhafTRpc Object 1"'} )
     expect(page).to have_xpath "//a[contains(@href,'?counter=1&access=curator')]"
+    expect(page).to have_link('QE8iWjhafTRpc Object 1', href:"/object/#{@obj1.pid}?counter=1&access=curator")
   end
  
   scenario 'decade faceting displays in chronological order ' do


### PR DESCRIPTION
https://github.com/ucsdlib/damsmanager/issues/110