### PR TITLE
Fixes #261 - Removed extra underscore from OG image URL

### DIFF
--- a/app/helpers/dams_objects_helper.rb
+++ b/app/helpers/dams_objects_helper.rb
@@ -359,7 +359,7 @@ module DamsObjectsHelper
       while file == 'no_display' && i < component_count do
         i = i + 1
 	    file = grabDisplayFile(componentIndex: i)
-        file = "_#{i}_#{file}" if file != 'no_display'
+        file = "#{i}_#{file}" if file != 'no_display'
       end
       return file
     end


### PR DESCRIPTION
Removed superfluous underscore from the filename of the image in the
Open Graph image URL for complex objects.