### PR TITLE
Fixes #287 - Make dams:license display publicly.

### DIFF
--- a/app/views/shared/fields/_show_raw.erb
+++ b/app/views/shared/fields/_show_raw.erb
@@ -85,8 +85,8 @@
          :exclude_label => ['digital object made available by'] }.merge(component) %>
 
 <%= render :partial => 'shared/fields/copyright', :locals => component %>
+<%= render :partial => 'shared/fields/license', :locals => component %>
 <% if can? :update, @document %>
-  <%= render :partial => 'shared/fields/license', :locals => component %>
   <%= render :partial => 'shared/fields/statute', :locals => component %>
   <%= render :partial => 'shared/fields/other_rights', :locals => component %>
 <% end %>

--- a/spec/features/dams_object_spec.rb
+++ b/spec/features/dams_object_spec.rb
@@ -247,7 +247,7 @@ feature 'Visitor want to look at objects' do
       expect(page).to have_selector('p', text: 'Test Polygon')
       expect(page).to have_selector('li', text: 'Test Unit')
 
-
+      expect(page).to have_selector('p', text: 'Creative Commons Attribution 4.0')
       expect(page).to have_selector('p', text: 'Test Preferred Citation Note')
       expect(page).to have_selector('p', text: 'Test Scope Content Note')
       expect(page).to have_selector('li', text: 'Test Cultural Context')
@@ -379,6 +379,7 @@ feature 'Visitor want to look at objects' do
 
       expect(page).to have_selector('p', text: 'Test Preferred Citation Note')
       expect(page).to have_selector('p', text: 'Test Scope Content Note')
+      expect(page).to have_selector('p', text: 'Creative Commons Attribution 4.0')
 
       expect(page).to have_selector('li', text: 'Test Cultural Context')
       expect(page).to have_selector('li', text: 'Test Common Name')


### PR DESCRIPTION
Fixes #287 ; refs #287

Make dams:license displayed on the public object viewer

Changes proposed in this pull request:
* Move license partial out of the curator restricted view
* Added test

@ucsdlib/developers - please review
