### PR TITLE
Fixes #306 - updated the Disqus link to use https.

### DIFF
--- a/app/views/dams_objects/_comments.html.erb
+++ b/app/views/dams_objects/_comments.html.erb
@@ -1,4 +1,4 @@
 <div id="disqus_thread"></div>
 <script type="text/javascript">
-	var disqus_shortname='dams4';(function(){var dsq = document.createElement('script');dsq.type='text/javascript';dsq.async=true;dsq.src='http://'+disqus_shortname+'.disqus.com/embed.js';(document.getElementsByTagName('head')[0]||document.getElementsByTagName('body')[0]).appendChild(dsq);})();
+	var disqus_shortname='dams4';(function(){var dsq = document.createElement('script');dsq.type='text/javascript';dsq.async=true;dsq.src='https://'+disqus_shortname+'.disqus.com/embed.js';(document.getElementsByTagName('head')[0]||document.getElementsByTagName('body')[0]).appendChild(dsq);})();
 </script>


### PR DESCRIPTION
Fixes #306

updated the Disqus link to use https.

@ucsdlib/developers - please review
