### PR TITLE
Remove display of Respository in the object level view

### DIFF
--- a/app/views/shared/fields/_show_raw.erb
+++ b/app/views/shared/fields/_show_raw.erb
@@ -92,8 +92,6 @@
 <% end %>
 
 <%= render :partial => 'shared/fields/rights_holder', :locals => component %>
-<%= render :partial => 'shared/fields/unit', :locals => component %>
-
 
 
 

--- a/app/views/shared/fields/_unit.html.erb
+++ b/app/views/shared/fields/_unit.html.erb
@@ -1,5 +1,0 @@
-<% if @document['unit_json_tesim'] != nil && !defined?(componentIndex)
-     unit = JSON.parse(@document['unit_json_tesim'].first) %>
-  <dt>Repository</dt>
-  <dd><ul><li><%= unit['name'] %></li></ul></dd>
-<% end %>

--- a/spec/features/dams_object_spec.rb
+++ b/spec/features/dams_object_spec.rb
@@ -245,7 +245,7 @@ feature 'Visitor want to look at objects' do
       expect(page).to have_selector('p', text: 'Test Point')
       expect(page).to have_selector('p', text: 'Test Line')
       expect(page).to have_selector('p', text: 'Test Polygon')
-      expect(page).to have_selector('li', text: 'Test Unit')
+      expect(page).to_not have_selector('li', text: 'Test Unit')
 
       expect(page).to have_selector('p', text: 'Creative Commons Attribution 4.0')
       expect(page).to have_selector('p', text: 'Test Preferred Citation Note')
@@ -373,7 +373,7 @@ feature 'Visitor want to look at objects' do
       expect(page).to have_selector('p', text: 'Test Point')
       expect(page).to have_selector('p', text: 'Test Line')
       expect(page).to have_selector('p', text: 'Test Polygon')
-      expect(page).to have_selector('li', text: 'Test Unit')
+      expect(page).to_not have_selector('li', text: 'Test Unit')
 
       expect(page).to have_content('Related Publications')
 


### PR DESCRIPTION
Fixes #332 ; refs #332 

Remove display of Respository in the object level view.

@ucsdlib/developers - please review
