### PR TITLE
sync circle-ci ruby version with rbenv .ruby-version

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -7,7 +7,7 @@ machine:
     version: 6.1.0
   ruby:
     version:
-      2.2.3        
+      2.3.6
   environment:
     CIRCLE_ENV: test
     RAILS_ENV: test
@@ -24,7 +24,3 @@ dependencies:
 database:
   override:
     - bundle exec rake db:migrate
-
-test:
-  post:
-    - bundle exec rspec


### PR DESCRIPTION
Changes proposed in this pull request:
* sync .ruby-version and circle-ci ruby versions to 2.3.6
* also remove extra test suite run. rspec is already configured to run
in the circle-ci dashboard, so removing the `test/post/bundle exec rspec` lines in the config file
which is causing a second run of the test suite

@ucsdlib/developers - please review
