### PR TITLE
Add Access note to browse by collection page for metadata-only collection 

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -28,6 +28,10 @@ Style/Documentation:
     - 'spec/**/*'
     - 'app/**/*'
 
+Style/ConditionalAssignment:
+  Exclude:
+    - 'app/helpers/*'
+    
 Style/Next:
   Enabled: true
 

--- a/app/helpers/catalog_helper.rb
+++ b/app/helpers/catalog_helper.rb
@@ -91,23 +91,21 @@ module CatalogHelper
     dateVal
   end
 
-  def display_access_control_level(document)
+  def display_access_control_level(document, metadata_colls)
+    access_group = document['read_access_group_ssim'] # "public" > "local" > "dams-curator" == "dams-rci" == default
+    view_access = 'Curator Only'
+    if access_group
 
-    accessGroup = document['read_access_group_ssim'] # "public" > "local" > "dams-curator" == "dams-rci" == default
-    viewAccess = nil
-
-    if accessGroup != nil
-
-      if accessGroup.include?('public')
-        viewAccess = nil
-      elsif accessGroup.include?('local')
-        viewAccess = 'Restricted to UC San Diego use only'
-      else
-        viewAccess = 'Curator Only'
+      if access_group.include?('public')
+        view_access = nil
+      elsif access_group.include?('local') && metadata_colls.include?(document['id'])
+        view_access = 'Restricted View'
+      elsif access_group.include?('local')
+        view_access = 'Restricted to UC San Diego use only'
       end
 
     end
-    viewAccess
+    view_access
   end
 
   def is_collection?( document )

--- a/app/views/catalog/_collection.html.erb
+++ b/app/views/catalog/_collection.html.erb
@@ -9,7 +9,7 @@
     <% end %> 
   <% end %>
 
-  <%= render :partial => 'catalog/display_access_control_level', :locals => {:document => document} %>
+  <%= render :partial => 'catalog/display_access_control_level', :locals => {:document => document, :metadata_colls => metadata_colls} %>
 
   <% dateVal = date_list(document) %>
   <% if !dateVal.blank? %>

--- a/app/views/catalog/_display_access_control_level.html.erb
+++ b/app/views/catalog/_display_access_control_level.html.erb
@@ -1,4 +1,4 @@
-<% acl = display_access_control_level(document) %>
+<% acl = display_access_control_level(document, metadata_colls) %>
 <% if acl != nil %>
   <li><span class="dams-search-results-fields-label">Access:</span> <span><%= acl %></span></li>
 <% end %>

--- a/app/views/catalog/_document.html.erb
+++ b/app/views/catalog/_document.html.erb
@@ -1,4 +1,4 @@
 <%# container for a single doc -%>
 <li>
-  <%= render :partial => 'document_header', :locals => { :document => document, :document_counter => document_counter } %>
+  <%= render :partial => 'document_header', :locals => { :document => document, :document_counter => document_counter, :metadata_colls => metadata_colls } %>
 </li>

--- a/app/views/catalog/_document_header.html.erb
+++ b/app/views/catalog/_document_header.html.erb
@@ -14,7 +14,7 @@
 
 	<%# main container for doc partial view -%>
     <% if is_collection?( document ) %>
-      <%= render :partial => 'collection', :locals => { :document => document } %>
+      <%= render :partial => 'collection', :locals => { :document => document, :metadata_colls => metadata_colls} %>
     <% else %>
 	  <%= render_document_partial document, :index %>
     <% end %>

--- a/app/views/catalog/_document_list.html.erb
+++ b/app/views/catalog/_document_list.html.erb
@@ -1,4 +1,4 @@
 <%# container for all documents in index view -%>
 <ol id="dams-search-results">
-  <%= render :collection => documents, :as => :document, :partial => 'document' %>
+  <%= render :collection => documents, :as => :document, :partial => 'document', locals: {:metadata_colls => metadata_colls} %>
 </ol>

--- a/app/views/catalog/_index_default.html.erb
+++ b/app/views/catalog/_index_default.html.erb
@@ -1,7 +1,7 @@
 <%# default partial to display solr document fields in catalog index view -%>
 <ul class="dams-search-results-fields">
 
-  <%= render :partial => 'catalog/display_access_control_level', :locals => {:document => document} %>
+  <%= render :partial => 'catalog/display_access_control_level', :locals => {:document => document, :metadata_colls => @metadata_colls} %>
 
   <% index_fields.each do |solr_fname, field| -%>
     <% if should_render_index_field? document, field %>

--- a/app/views/catalog/collection_search.html.erb
+++ b/app/views/catalog/collection_search.html.erb
@@ -16,8 +16,7 @@
     <%= render 'sort_and_per_page' %>
     <%#= render :partial => 'constraints' %>
     <h3 class="hide-text"><%= t('blacklight.search.search_results') %></h3>
-    <%= render_document_index %>
-
+    <%= render :partial => 'document_list', locals: {:documents => @document_list, :metadata_colls => @metadata_colls}%>
     <%#= render 'results_pagination' %>
     <div class="dams-search-results-footer">
       <%= render :partial => 'paginate_compact' %>

--- a/app/views/catalog/index.html.erb
+++ b/app/views/catalog/index.html.erb
@@ -26,7 +26,7 @@
       <%= render 'sort_and_per_page' %>
 			<%= render :partial => 'spellcheck' %>
 			<h3 class="hide-text"><%= t('blacklight.search.search_results') %></h3>
-			<%= render_document_index %>
+			<%= render :partial => 'document_list', locals: {:documents => @document_list, :metadata_colls => @metadata_colls}%>
 			<div class="dams-search-results-footer">
 				<%= render :partial => 'paginate_compact' %>
 			</div>

--- a/spec/features/access_control_spec.rb
+++ b/spec/features/access_control_spec.rb
@@ -35,7 +35,7 @@ feature 'Access control' do
     visit catalog_index_path( {:q => 'object'} )
     expect(page).to have_selector('h3', 'Public Object')
     expect(page).to have_no_content('Curator Object')
-    expect(page).to have_no_content('Local Object')
+    expect(page).to have_content('Local Object')
     expect(page).to have_no_content('Hidden Object')
   end
   scenario 'anonymous user viewing public object' do
@@ -50,8 +50,7 @@ feature 'Access control' do
   end
   scenario 'anonymous user viewing local object' do
     visit dams_object_path @localObj.pid
-    expect(page).to have_selector('h1','You are not allowed to view this page.')
-    expect(page).to have_no_content('Local Object')
+    expect(page).to have_content('Local Object')
   end
   scenario 'anonymous user viewing file attached to hidden object' do
     visit file_path( @hiddenObj, '_1.txt' )

--- a/spec/features/dams_collections_spec.rb
+++ b/spec/features/dams_collections_spec.rb
@@ -392,4 +392,10 @@ feature "Visitor wants to view a UCSD IP only collection's page with metadata-on
     visit dams_collection_path @collection.pid
     expect(page).to_not have_content('Restricted View')
   end
+  
+  scenario 'should see Restricted View access control information when visit browse by collection page' do
+    sign_in_anonymous '132.239.0.3'
+    visit '/collections'
+    expect(page).to have_content('Restricted View')
+  end  
 end


### PR DESCRIPTION
Fixes #409  ; refs #409 

Display the access note for metadata-only view collections.

@ucsdlib/developers - please review
