### PR TITLE
Add generic thumbnail and restricted view info to search objects view

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -11,8 +11,7 @@ AllCops:
     - 'doc/**/*'
     - 'spec/**/*'
     - 'test/**/*'
-    - 'app/helpers/application_helper.rb'
-    - 'app/helpers/dams_objects_helper.rb'
+    - 'app/helpers/**/*'
 
 Rails:
     Enabled: true

--- a/app/helpers/catalog_helper.rb
+++ b/app/helpers/catalog_helper.rb
@@ -139,7 +139,19 @@ module CatalogHelper
     
     image_tag( url, :alt => "", :class => 'dams-search-thumbnail')
   end
-    
+
+  def object_thumbnail_url(document)
+    access = grab_access_text(document)
+    restricted = grabRestrictedText(document['otherNote_json_tesim'])
+    return nil unless access || restricted || (has_thumbnail?(document) && thumbnail_url(document, nil))
+    if access || restricted
+      url = 'https://library.ucsd.edu/assets/dams/site/thumb-restricted.png'
+      image_tag(url, alt: '', class: 'dams-search-thumbnail')
+    else
+      thumbnail_url(document, nil)
+    end
+  end
+
   def document_icon( document )
     # generic default icon
     resultClass = 'thumb-simple'

--- a/app/helpers/catalog_helper.rb
+++ b/app/helpers/catalog_helper.rb
@@ -1,5 +1,6 @@
 module CatalogHelper
   include Blacklight::CatalogHelperBehavior
+  include Dams::ControllerHelper
 
   # link_to_document(doc, :label=>'VIEW', :counter => 3)
   # Use the catalog_path RESTful route to create a link to the show page for a specific item.
@@ -93,12 +94,13 @@ module CatalogHelper
 
   def display_access_control_level(document, metadata_colls)
     access_group = document['read_access_group_ssim'] # "public" > "local" > "dams-curator" == "dams-rci" == default
+    other_rights = document['otherRights_tesim']
     view_access = 'Curator Only'
     if access_group
 
       if access_group.include?('public')
         view_access = nil
-      elsif access_group.include?('local') && metadata_colls.include?(document['id'])
+      elsif access_group.include?('local') && (metadata_colls.include?(document['id']) || metadata_display?(other_rights))
         view_access = 'Restricted View'
       elsif access_group.include?('local')
         view_access = 'Restricted to UC San Diego use only'

--- a/app/views/catalog/_document_thumbnail.html.erb
+++ b/app/views/catalog/_document_thumbnail.html.erb
@@ -8,12 +8,18 @@
     url = to_stats_path url
     
     restrictedNotice = grabRestrictedText(document['otherNote_json_tesim'])
+    access_notice = grab_access_text(document)
 %>
+
 <%= link_to url, :class => 'dams-search-thumbnail-link' do %>
   <%- if !restrictedNotice.nil? && rtn = restricted_object_url%>
     <div class="document-thumbnail dams-search-thumbnail">
       <%= rtn %>
     </div> 
+  <%- elsif access_notice && rtn = restricted_object_url%>
+    <div class="document-thumbnail dams-search-thumbnail">
+      <%= rtn %>
+    </div>
   <%- elsif has_thumbnail?(document) && tn = thumbnail_url(document, nil)%>
     <div class="document-thumbnail dams-search-thumbnail">
       <%= tn %>

--- a/app/views/catalog/_document_thumbnail.html.erb
+++ b/app/views/catalog/_document_thumbnail.html.erb
@@ -6,23 +6,12 @@
     end
 
     url = to_stats_path url
-    
-    restrictedNotice = grabRestrictedText(document['otherNote_json_tesim'])
-    access_notice = grab_access_text(document)
 %>
 
 <%= link_to url, :class => 'dams-search-thumbnail-link' do %>
-  <%- if !restrictedNotice.nil? && rtn = restricted_object_url%>
+  <%- if object_thumbnail_url(document)%>
     <div class="document-thumbnail dams-search-thumbnail">
-      <%= rtn %>
-    </div> 
-  <%- elsif access_notice && rtn = restricted_object_url%>
-    <div class="document-thumbnail dams-search-thumbnail">
-      <%= rtn %>
-    </div>
-  <%- elsif has_thumbnail?(document) && tn = thumbnail_url(document, nil)%>
-    <div class="document-thumbnail dams-search-thumbnail">
-      <%= tn %>
+      <%= object_thumbnail_url(document)  %>
     </div>  
   <%- else %>
     <% resultClass, resultIcon = document_icon( document ) %>

--- a/spec/features/catalog_spec.rb
+++ b/spec/features/catalog_spec.rb
@@ -500,6 +500,32 @@ feature 'Visitor wants to view icons for the objects in the search result page' 
   end
 end
 
+feature 'Visitor wants to view object of metadata data-only visibility collection in the search result page' do
+  before(:all) do
+    ns = Rails.configuration.id_namespace
+    @note = DamsNote.create type: "local attribution", value: "Digital Library Development Program, UC San Diego, La Jolla, 92093-0175"
+    @localDisplay = DamsOtherRight.create permissionType: "localDisplay"
+    @localOnlyCollection = DamsProvenanceCollection.create titleValue: "Test UCSD IP only Collection with localDisplay visibility", visibility: "local"    
+    @localObj = DamsObject.create pid: 'xx909090zz', titleValue: 'Test Object with localDisplay', provenanceCollectionURI: @localOnlyCollection.pid, otherRightsURI: @localDisplay.pid, note_attributes: [{ id: RDF::URI.new("#{ns}#{@note.pid}") }], copyright_attributes: [{status: 'Public domain'}]
+    solr_index @note.pid
+    solr_index @localDisplay.pid
+    solr_index @localOnlyCollection.pid
+    solr_index @localObj.pid
+  end
+  after(:all) do
+    @note.delete
+    @localDisplay.delete
+    @localOnlyCollection.delete
+    @localObj.delete
+  end
+  scenario 'rendering the grey generic thumbnail and restricted access info' do
+    sign_in_developer
+    visit catalog_index_path({:q => 'xx909090zz'})
+    expect(page).to have_css('img.dams-search-thumbnail[src="https://library.ucsd.edu/assets/dams/site/thumb-restricted.png"]')
+    expect(page).to have_content('Restricted View')
+  end
+end
+
 feature 'Visitor wants to view contact form' do
   scenario 'rendering the contact form' do
     sign_in_developer


### PR DESCRIPTION
Fixes #411  ; refs #411 

Add grey generic thumbnails and restricted view access info for objects of metadata data-only visibility collections.

@ucsdlib/developers - please review
