### PR TITLE
Add restricted note info to complex object view

### DIFF
--- a/app/assets/javascripts/views-object.js
+++ b/app/assets/javascripts/views-object.js
@@ -299,6 +299,12 @@ $(document).ready(function()
         $(".simple-object, .first-component, .dams-sidebar").hide();
     }
 
+    // Hide content if "restricted view notice" present
+    if($(".restricted-notice-complex").length)
+    {
+        $(".simple-object").hide();
+    }
+    
     // Show hidden "restricted notice" objects
     $("#view-masked-object").click(function() {        
         $('.restricted-notice').hide();

--- a/app/assets/stylesheets/custom-object-viewer.css.scss
+++ b/app/assets/stylesheets/custom-object-viewer.css.scss
@@ -103,7 +103,7 @@ $complexFile: #AC6F2B !default;
 .file-thumbnail img{margin-bottom: 20px;}
 
 // Masked Objects (Restricted, Sensitive, etc.)
-.restricted-notice
+.restricted-notice, .restricted-notice-complex
 {
   background:#b1b1b1 url(https://library.ucsd.edu/assets/dams/site/restricted.png) no-repeat center center;
   background-size:150%,150%;

--- a/app/views/dams_objects/_audio_viewer_complex.html.erb
+++ b/app/views/dams_objects/_audio_viewer_complex.html.erb
@@ -8,9 +8,10 @@
    dataForDynamicLoad = "{\"file_type\":\"audio\",\"display_file_path\":\"\",\"service_file_path\":\"#{wowzaURL}\"}"
 %>
 
-<% if wowzaURL != nil %>
+<% if access_notice.nil? && wowzaURL != nil %>
 
   <div id="dams-audio-<%=componentIndex%>" data='<%=dataForDynamicLoad%>'>Loading the player...</div>
 
 <% end %>
-<%= render :partial => 'admin_download', :locals => {:downloadFilePath => downloadFilePath, :downloadDerivativePath => downloadDerivativePath  } %>
+
+<%= render :partial => 'admin_download', :locals => {:downloadFilePath => downloadFilePath, :downloadDerivativePath => downloadDerivativePath  } if access_notice.nil?%>

--- a/app/views/dams_objects/_complex_object_viewer.html.erb
+++ b/app/views/dams_objects/_complex_object_viewer.html.erb
@@ -15,6 +15,7 @@
     </div>
   </div>
 <% end %>
+<% access_notice = grab_access_text(@document) if cannot? :update, @document %>
 
 <section id="le-component">
 
@@ -54,48 +55,44 @@
 
             isFirstComponent = (i == 1) ? true : false
         %>
-
 		<div id="component-<%= i %>" class="component <%= firstComponent if isFirstComponent %>" <%= loadFirstComponent if isFirstComponent %>>
 
 			<%= render :partial => 'shared/fields/title', :locals => {:componentIndex => i} %>
-
+			<%= render :partial => 'restricted_access', :locals => {:access_notice => access_notice } %>
 			<% if fileType == 'image' %>
-
+                            <% if access_notice.nil? %>
 				<% zoom_file_path = zoom_path(ark, "#{i}") %>
 				<% dataForDynamicLoad = "{\"file_type\":\"image\",\"display_file_path\":\"#{display_file_path}\",\"service_file_path\":\"#{zoom_file_path}\",\"download_file_path\":\"#{download_file_path}\"}" %>
 
 				<div data='<%=dataForDynamicLoad%>'></div>
+                            <% end %>
 		    <%= render :partial => 'metadata_component', :locals => {:componentIndex => i} %>
-		    <%= render :partial => 'admin_download', :locals => {:downloadFilePath => download_file_path, :downloadDerivativePath => service_file_path  } %>
+		    <%= render :partial => 'admin_download', :locals => {:downloadFilePath => download_file_path, :downloadDerivativePath => service_file_path  } if access_notice.nil?%>
 
 		  <% elsif fileType == 'audio' %>
-
-		    <%= render :partial => 'audio_viewer_complex', :locals => {:componentIndex => i, :downloadFilePath => download_file_path, :downloadDerivativePath => nil  } %>
+		    <%= render :partial => 'audio_viewer_complex', :locals => {:access_notice => access_notice, :componentIndex => i, :downloadFilePath => download_file_path, :downloadDerivativePath => nil  } %>
 		    <%= render :partial => 'metadata_component', :locals => {:componentIndex => i} %>
 
 		  <% elsif fileType == 'video' %>
 
-		    <%= render :partial => 'video_viewer_complex', :locals => {:componentIndex => i, :downloadFilePath => download_file_path, :downloadDerivativePath => service_file_path  } %>
+		    <%= render :partial => 'video_viewer_complex', :locals => {:access_notice => access_notice, :componentIndex => i, :downloadFilePath => download_file_path, :downloadDerivativePath => service_file_path  } %>
 		    <%= render :partial => 'metadata_component', :locals => {:componentIndex => i} %>
 
 		  <% elsif fileType == 'document' %>
 
-		    <%= render :partial => 'document_viewer', :locals => {:filePath => service_file_path, :displayFilePath => display_file_path, :downloadDerivativePath => service_file_path  } %>
+		    <%= render :partial => 'document_viewer', :locals => {:access_notice => access_notice, :filePath => service_file_path, :displayFilePath => display_file_path, :downloadDerivativePath => service_file_path  } %>
 		    <%= render :partial => 'metadata_component', :locals => {:componentIndex => i, :fileMetadata => true, :fileName => service_file} %>
-		    <%= render :partial => 'data_viewer', :locals => {:objectType => 'complex', :filePath => service_file_path, :downloadDerivativePath => service_file_path, :sourcefilePath => source_file_path  } %>
+		    <%= render :partial => 'data_viewer', :locals => {:objectType => 'complex', :filePath => service_file_path, :downloadDerivativePath => service_file_path, :sourcefilePath => source_file_path  } if access_notice.nil?%>
 
 			<% elsif fileType == 'data' %>
-
 		    <%= render :partial => 'metadata_component', :locals => {:componentIndex => i, :fileMetadata => true, :fileName => service_file} %>
-				<%= render :partial => 'data_viewer', :locals => {:objectType => 'complex', :filePath => service_file_path, :downloadDerivativePath => service_file_path, :sourcefilePath => source_file_path  } %>
+				<%= render :partial => 'data_viewer', :locals => {:objectType => 'complex', :filePath => service_file_path, :downloadDerivativePath => service_file_path, :sourcefilePath => source_file_path  } if access_notice.nil?%>
 	        <% elsif fileType == 'text' %>
 		      <%= render :partial => 'metadata_component', :locals => {:componentIndex => i, :fileMetadata => true, :fileName => service_file} %>
-			  <%= render :partial => 'text_viewer', :locals => {:objectType => 'complex', :downloadFilePath => download_file_path, :downloadDerivativePath => service_file_path  } %>
+			  <%= render :partial => 'text_viewer', :locals => {:objectType => 'complex', :downloadFilePath => download_file_path, :downloadDerivativePath => service_file_path  } if access_notice.nil?%>
 			<% else %>
-
 				<%= render :partial => 'metadata_component', :locals => {:componentIndex => i} %>
-				<%= render :partial => 'default_viewer', :locals => {:objectType => 'complex'} %>
-
+				<%= render :partial => 'default_viewer', :locals => {:objectType => 'complex'} %>				
 			<% end %>
 
 		</div>
@@ -104,4 +101,4 @@
 
 	<% end %>
 
-</section>
+</section> 

--- a/app/views/dams_objects/_document_viewer.html.erb
+++ b/app/views/dams_objects/_document_viewer.html.erb
@@ -1,4 +1,4 @@
-<% if defined?(filePath) and defined?(displayFilePath)%>
+<% if access_notice.nil? and defined?(filePath) and defined?(displayFilePath)%>
 
   <% viewFilePath = filePath.gsub('/download', '') %>
   

--- a/app/views/dams_objects/_restricted_access.html.erb
+++ b/app/views/dams_objects/_restricted_access.html.erb
@@ -1,0 +1,9 @@
+<% if cannot? :update, @document then %>
+  <% if access_notice %>
+    <div class="restricted-notice-complex">
+      <div>
+        <%= access_notice %>
+      </div>
+    </div>
+  <% end %>
+<% end %>

--- a/app/views/dams_objects/_simple_object_viewer.html.erb
+++ b/app/views/dams_objects/_simple_object_viewer.html.erb
@@ -37,7 +37,7 @@
 		<% when 'video-service' %>
 			<%= render :partial => 'video_viewer', :locals => {:filePath => service_file_path, :icon => display_file_path, :downloadFilePath => download_file_path, :downloadDerivativePath => download_derivative_path} %>
 		<% when 'document-service' %>
-	    <%= render :partial => 'document_viewer', :locals => {:filePath => service_file_path, :displayFilePath => display_file_path, :downloadDerivativePath => download_derivative_path} %>
+	    <%= render :partial => 'document_viewer', :locals => {:access_notice => nil, :filePath => service_file_path, :displayFilePath => display_file_path, :downloadDerivativePath => download_derivative_path} %>
 			<%= render :partial => 'metadata_data_file', :locals => {:fileName => service_file} %>
 			<%= render :partial => 'data_viewer', :locals => {:displayFilePath => display_file_path, :filePath => service_file_path, :objectType => 'simple', :pdfFilePath => pdf_file_path, :sourcefilePath => source_file_path} %>
 		<% when 'data-service' %>

--- a/app/views/dams_objects/_video_viewer_complex.html.erb
+++ b/app/views/dams_objects/_video_viewer_complex.html.erb
@@ -7,9 +7,7 @@
    dataForDynamicLoad = "{\"file_type\":\"video\",\"display_file_path\":\"\",\"service_file_path\":\"#{wowzaURL}\"}"
 %>
 
-<% if wowzaURL != nil %>
-
+<% if access_notice.nil? && wowzaURL != nil %>
   <video controls="controls" id="dams-video-<%=componentIndex%>" data='<%=dataForDynamicLoad%>'>Loading the player...</video>
-
 <% end %>
-<%= render :partial => 'admin_download', :locals => {:downloadFilePath => downloadFilePath, :downloadDerivativePath => downloadDerivativePath  } %>
+<%= render :partial => 'admin_download', :locals => {:downloadFilePath => downloadFilePath, :downloadDerivativePath => downloadDerivativePath  } if access_notice.nil?%>

--- a/spec/fixtures/damsComplexObject10.rdf.xml
+++ b/spec/fixtures/damsComplexObject10.rdf.xml
@@ -1,0 +1,337 @@
+<rdf:RDF
+    xmlns:mads="http://www.loc.gov/mads/rdf/v1#"
+    xmlns:damsid="http://library.ucsd.edu/ark:/20775/"
+    xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+    xmlns:owl="http://www.w3.org/2002/07/owl#"
+    xmlns:dams="http://library.ucsd.edu/ontology/dams#">
+  <dams:Object rdf:about="http://library.ucsd.edu/ark:/20775/xx99999999">
+    
+    <dams:hasComponent>
+      <dams:Component rdf:about="http://library.ucsd.edu/ark:/20775/xx99999999/2">
+        <dams:hasComponent>
+          <dams:Component rdf:about="http://library.ucsd.edu/ark:/20775/xx99999999/3">
+            <dams:title>
+              <mads:Title>
+                <mads:authoritativeLabel>Dredge photographs</mads:authoritativeLabel>
+                <mads:elementList rdf:parseType="Collection">
+                  <mads:MainTitleElement>
+                    <mads:elementValue>Dredge photographs</mads:elementValue>
+                  </mads:MainTitleElement>
+                </mads:elementList>
+              </mads:Title>
+            </dams:title>
+            <dams:order>1</dams:order>
+            <dams:hasComponent>
+              <dams:Component rdf:about="http://library.ucsd.edu/ark:/20775/xx99999999/4">
+                <dams:title>
+                  <mads:Title>
+                    <mads:elementList rdf:parseType="Collection">
+                      <mads:MainTitleElement>
+                        <mads:elementValue>Image 001</mads:elementValue>
+                      </mads:MainTitleElement>
+                    </mads:elementList>
+                    <mads:authoritativeLabel>Image 001</mads:authoritativeLabel>
+                  </mads:Title>
+                </dams:title>
+                <dams:order>1</dams:order>
+                <dams:hasFile>
+                  <dams:File rdf:about="http://library.ucsd.edu/ark:/20775/xx99999999/4/4.jpg">
+                    <dams:preservationLevel>full</dams:preservationLevel>
+                    <dams:sourceFileName>jhovetmp7957176984930577534.jpg</dams:sourceFileName>
+                    <dams:sha1checksum>9c06f7600e92ba5fb05446e33b0349b8e48fe261</dams:sha1checksum>
+                    <dams:use>image-thumbnail</dams:use>
+                    <dams:size>19109</dams:size>
+                    <dams:sourcePath>/usr/local/tomcat/temp</dams:sourcePath>
+                    <dams:formatVersion>1.01</dams:formatVersion>
+                    <dams:dateCreated>2013-12-12T08:16:57-0800</dams:dateCreated>
+                    <dams:objectCategory>file</dams:objectCategory>
+                    <dams:event rdf:resource="http://library.ucsd.edu/ark:/20775/bd32794444"/>
+                    <dams:crc32checksum>b05c2f69</dams:crc32checksum>
+                    <dams:mimeType>image/jpeg</dams:mimeType>
+                    <dams:compositionLevel>0</dams:compositionLevel>
+                    <dams:filestore>openStack</dams:filestore>
+                    <dams:quality>150x100</dams:quality>
+                    <dams:formatName>JPEG</dams:formatName>
+                    <dams:md5checksum>106071896711ad0774803c71dbf20b1f</dams:md5checksum>
+                  </dams:File>
+                </dams:hasFile>
+                <dams:hasFile>
+                  <dams:File rdf:about="http://library.ucsd.edu/ark:/20775/xx99999999/4/7.jpg">
+                    <dams:preservationLevel>full</dams:preservationLevel>
+                    <dams:crc32checksum>38f290a4</dams:crc32checksum>
+                    <dams:md5checksum>d3bbfd689ccd4ce3439a3554ef05ad45</dams:md5checksum>
+                    <dams:formatName>JPEG</dams:formatName>
+                    <dams:use>image-huge</dams:use>
+                    <dams:filestore>openStack</dams:filestore>
+                    <dams:sourceFileName>jhovetmp8792219027437235170.jpg</dams:sourceFileName>
+                    <dams:sha1checksum>63eb643c9925a17d7cd11d203222e55daad3f012</dams:sha1checksum>
+                    <dams:formatVersion>1.01</dams:formatVersion>
+                    <dams:objectCategory>file</dams:objectCategory>
+                    <dams:sourcePath>/usr/local/tomcat/temp</dams:sourcePath>
+                    <dams:compositionLevel>0</dams:compositionLevel>
+                    <dams:event rdf:resource="http://library.ucsd.edu/ark:/20775/bd0685566r"/>
+                    <dams:mimeType>image/jpeg</dams:mimeType>
+                    <dams:size>384000</dams:size>
+                    <dams:quality>1600x1067</dams:quality>
+                    <dams:dateCreated>2013-12-12T08:16:50-0800</dams:dateCreated>
+                  </dams:File>
+                </dams:hasFile>
+                <dams:hasFile>
+                  <dams:File rdf:about="http://library.ucsd.edu/ark:/20775/xx99999999/4/6.jpg">
+                    <dams:objectCategory>file</dams:objectCategory>
+                    <dams:md5checksum>57f33c5c6bd2da1b42a445c4523d259e</dams:md5checksum>
+                    <dams:formatName>JPEG</dams:formatName>
+                    <dams:mimeType>image/jpeg</dams:mimeType>
+                    <dams:crc32checksum>476f5986</dams:crc32checksum>
+                    <dams:sha1checksum>372b53ec488b9b1e4f2d3d1b44d44c672059575e</dams:sha1checksum>
+                    <dams:size>180256</dams:size>
+                    <dams:event rdf:resource="http://library.ucsd.edu/ark:/20775/bd5873324x"/>
+                    <dams:sourceFileName>jhovetmp459538904546600193.jpg</dams:sourceFileName>
+                    <dams:filestore>openStack</dams:filestore>
+                    <dams:dateCreated>2013-12-12T08:16:53-0800</dams:dateCreated>
+                    <dams:sourcePath>/usr/local/tomcat/temp</dams:sourcePath>
+                    <dams:formatVersion>1.01</dams:formatVersion>
+                    <dams:preservationLevel>full</dams:preservationLevel>
+                    <dams:compositionLevel>0</dams:compositionLevel>
+                    <dams:use>image-large</dams:use>
+                    <dams:quality>1024x683</dams:quality>
+                  </dams:File>
+                </dams:hasFile>
+                <dams:hasFile>
+                  <dams:File rdf:about="http://library.ucsd.edu/ark:/20775/xx99999999/4/2.jpg">
+                    <dams:dateCreated>2013-12-12T08:16:47-0800</dams:dateCreated>
+                    <dams:compositionLevel>0</dams:compositionLevel>
+                    <dams:mimeType>image/jpeg</dams:mimeType>
+                    <dams:sha1checksum>97077868006d75919dc2e2acdab9be231b935227</dams:sha1checksum>
+                    <dams:formatVersion>1.01</dams:formatVersion>
+                    <dams:preservationLevel>full</dams:preservationLevel>
+                    <dams:formatName>JPEG</dams:formatName>
+                    <dams:sourceFileName>jhovetmp2427373142421224682.jpg</dams:sourceFileName>
+                    <dams:size>111807</dams:size>
+                    <dams:use>image-service</dams:use>
+                    <dams:sourcePath>/usr/local/tomcat/temp</dams:sourcePath>
+                    <dams:filestore>openStack</dams:filestore>
+                    <dams:crc32checksum>3115372b</dams:crc32checksum>
+                    <dams:md5checksum>3bbd16d72b0602cb8a9eafa52c8e9c4a</dams:md5checksum>
+                    <dams:event rdf:resource="http://library.ucsd.edu/ark:/20775/bd1982503d"/>
+                    <dams:quality>768x512</dams:quality>
+                    <dams:objectCategory>file</dams:objectCategory>
+                  </dams:File>
+                </dams:hasFile>
+                <dams:hasFile>
+                  <dams:File rdf:about="http://library.ucsd.edu/ark:/20775/xx99999999/4/3.jpg">
+                    <dams:sourcePath>/usr/local/tomcat/temp</dams:sourcePath>
+                    <dams:quality>450x300</dams:quality>
+                    <dams:preservationLevel>full</dams:preservationLevel>
+                    <dams:sourceFileName>jhovetmp1967571600967591238.jpg</dams:sourceFileName>
+                    <dams:use>image-preview</dams:use>
+                    <dams:size>51374</dams:size>
+                    <dams:mimeType>image/jpeg</dams:mimeType>
+                    <dams:formatVersion>1.01</dams:formatVersion>
+                    <dams:sha1checksum>064d57360243a3aeb8c20199134b295fb716b174</dams:sha1checksum>
+                    <dams:formatName>JPEG</dams:formatName>
+                    <dams:compositionLevel>0</dams:compositionLevel>
+                    <dams:crc32checksum>fd46378c</dams:crc32checksum>
+                    <dams:event rdf:resource="http://library.ucsd.edu/ark:/20775/bd94228456"/>
+                    <dams:md5checksum>f83b0cd54326fad99bcb9f220f043dbb</dams:md5checksum>
+                    <dams:filestore>openStack</dams:filestore>
+                    <dams:objectCategory>file</dams:objectCategory>
+                    <dams:dateCreated>2013-12-12T08:16:45-0800</dams:dateCreated>
+                  </dams:File>
+                </dams:hasFile>
+                <dams:hasFile>
+                  <dams:File rdf:about="http://library.ucsd.edu/ark:/20775/xx99999999/4/5.jpg">
+                    <dams:crc32checksum>8c0345bd</dams:crc32checksum>
+                    <dams:size>14933</dams:size>
+                    <dams:sourcePath>/usr/local/tomcat/temp</dams:sourcePath>
+                    <dams:use>image-icon</dams:use>
+                    <dams:event rdf:resource="http://library.ucsd.edu/ark:/20775/bd7170264c"/>
+                    <dams:md5checksum>1f82dc3a8a5a1b959d4d94ac76da3111</dams:md5checksum>
+                    <dams:sourceFileName>jhovetmp4690185074321915308.jpg</dams:sourceFileName>
+                    <dams:compositionLevel>0</dams:compositionLevel>
+                    <dams:mimeType>image/jpeg</dams:mimeType>
+                    <dams:filestore>openStack</dams:filestore>
+                    <dams:sha1checksum>73c77d84699460c8d3bccc03534fc5f751a60d82</dams:sha1checksum>
+                    <dams:dateCreated>2013-12-12T08:16:55-0800</dams:dateCreated>
+                    <dams:quality>65x43</dams:quality>
+                    <dams:formatName>JPEG</dams:formatName>
+                    <dams:preservationLevel>full</dams:preservationLevel>
+                    <dams:formatVersion>1.01</dams:formatVersion>
+                    <dams:objectCategory>file</dams:objectCategory>
+                  </dams:File>
+                </dams:hasFile>
+                <dams:hasFile>
+                  <dams:File rdf:about="http://library.ucsd.edu/ark:/20775/xx99999999/4/1.jpg">
+                    <dams:md5checksum>f376fa85ff01264a9022e7d906ce255f</dams:md5checksum>
+                    <dams:crc32checksum>fcbee4fd</dams:crc32checksum>
+                    <dams:sourcePath>/pub/data1/dams_staging/rci/staging/siogeocoll/PPTU_RCI_Apr2013_Bag/data/PPTU/Dredge_Photos</dams:sourcePath>
+                    <dams:sourceFileName>pptu04wt-027d_dredgephotograph_001.jpg</dams:sourceFileName>
+                    <dams:sha1checksum>2ac7a5e5917798e56cd0ab41a241a1ea24f96f49</dams:sha1checksum>
+                    <dams:compositionLevel>0</dams:compositionLevel>
+                    <dams:objectCategory>file</dams:objectCategory>
+                    <dams:event rdf:resource="http://library.ucsd.edu/ark:/20775/bd4576384q"/>
+                    <dams:use>image-source</dams:use>
+                    <dams:dateCreated>2013-04-17T02:18:11-0700</dams:dateCreated>
+                    <dams:size>2348655</dams:size>
+                    <dams:quality>3504x2336</dams:quality>
+                    <dams:formatName>JPEG</dams:formatName>
+                    <dams:filestore>openStack</dams:filestore>
+                    <dams:mimeType>image/jpeg</dams:mimeType>
+                    <dams:preservationLevel>full</dams:preservationLevel>
+                  </dams:File>
+                </dams:hasFile>
+              </dams:Component>
+            </dams:hasComponent>
+            <dams:typeOfResource>data</dams:typeOfResource>
+          </dams:Component>
+        </dams:hasComponent>
+        <dams:title>
+          <mads:Title>
+            <mads:elementList rdf:parseType="Collection">
+              <mads:MainTitleElement>
+                <mads:elementValue>Files</mads:elementValue>
+              </mads:MainTitleElement>
+            </mads:elementList>
+            <mads:authoritativeLabel>Files</mads:authoritativeLabel>
+          </mads:Title>
+        </dams:title>
+        <dams:order>2</dams:order>
+      </dams:Component>
+    </dams:hasComponent>
+    <dams:cartographics>
+      <dams:Cartographics>
+        <dams:line>-17.615,-176.033 -17.6,-176</dams:line>
+        <dams:referenceSystem>WGS84</dams:referenceSystem>
+      </dams:Cartographics>
+    </dams:cartographics>
+    
+    <dams:note>
+      <dams:Note>
+        <dams:displayLabel>IGSN</dams:displayLabel>
+        <dams:type>identifier</dams:type>
+        <rdf:value>SIO001701</rdf:value>
+      </dams:Note>
+    </dams:note>
+
+    <dams:note>
+      <dams:Note>
+        <dams:type>local attribution</dams:type>
+        <dams:displayLabel>digital object made available by</dams:displayLabel>
+        <rdf:value>Research Data Curation Program, UC San Diego, La Jolla, 92093-0175 (https://lib.ucsd.edu/rdcp)</rdf:value>
+      </dams:Note>
+    </dams:note>    
+    
+    <dams:note>
+      <dams:Note>
+        <dams:displayLabel>water depth</dams:displayLabel>
+        <dams:type>material details</dams:type>
+        <rdf:value>2487-2402 meters</rdf:value>
+      </dams:Note>
+    </dams:note>
+    <dams:date>
+      <dams:Date>
+        <rdf:value>1986-01-20</rdf:value>
+        <dams:endDate>1986-01-20</dams:endDate>
+        <dams:beginDate>1986-01-20</dams:beginDate>
+        <dams:encoding>w3cdtf</dams:encoding>
+        <dams:type>creation</dams:type>
+      </dams:Date>
+    </dams:date>
+    <dams:hasComponent>
+      <dams:Component rdf:about="http://library.ucsd.edu/ark:/20775/xx99999999/1">
+        <dams:order>1</dams:order>
+        <dams:title>
+          <mads:Title>
+            <mads:authoritativeLabel>Interval 1 (dredge, rock)</mads:authoritativeLabel>
+            <mads:elementList rdf:parseType="Collection">
+              <mads:MainTitleElement>
+                <mads:elementValue>Interval 1 (dredge, rock)</mads:elementValue>
+              </mads:MainTitleElement>
+            </mads:elementList>
+          </mads:Title>
+        </dams:title>
+        <dams:note>
+          <dams:Note>
+            <rdf:value>20LBS. PUMICE,BUFF/TAN SILTSTONE, ALTERED BASALT.</rdf:value>
+            <dams:type>description</dams:type>
+          </dams:Note>
+        </dams:note>
+       
+        <dams:commonName>
+          <dams:CommonName>
+            <mads:authoritativeLabel>thale-cress componentt</mads:authoritativeLabel>
+              <mads:elementList rdf:parseType="Collection">
+                <dams:CommonNameElement>
+                  <mads:elementValue>thale-cress component</mads:elementValue>
+              </dams:CommonNameElement>
+            </mads:elementList>
+          </dams:CommonName>
+        </dams:commonName>
+        <dams:note>
+          <dams:Note>
+            <rdf:value>weathering - light</rdf:value>
+            <dams:type>material details</dams:type>
+            <dams:displayLabel>rock weather/metamorphism</dams:displayLabel>
+          </dams:Note>
+        </dams:note>
+        <dams:note>
+          <dams:Note>
+            <rdf:value>no glass</rdf:value>
+            <dams:type>material details</dams:type>
+            <dams:displayLabel>rock glass and Mn/Fe oxide</dams:displayLabel>
+          </dams:Note>
+        </dams:note>
+      </dams:Component>
+    </dams:hasComponent>
+    <dams:note>
+      <dams:Note>
+        <dams:displayLabel>storage method</dams:displayLabel>
+        <dams:type>material details</dams:type>
+        <rdf:value>room temperature, dry</rdf:value>
+      </dams:Note>
+    </dams:note>
+    
+    <dams:typeOfResource>data</dams:typeOfResource>
+   
+    <dams:title>
+      <mads:Title>
+        <mads:elementList rdf:parseType="Collection">
+          <mads:MainTitleElement>
+            <mads:elementValue>Test Object with metadataOnly Display</mads:elementValue>
+          </mads:MainTitleElement>
+        </mads:elementList>
+        <mads:authoritativeLabel>Test Object with metadataOnly Display</mads:authoritativeLabel>
+      </mads:Title>
+    </dams:title>
+    <dams:commonName>
+      <dams:CommonName rdf:about="http://library.ucsd.edu/ark:/20775/xx484848cn">
+        <mads:authoritativeLabel>thale-cress</mads:authoritativeLabel>
+        <mads:elementList rdf:parseType="Collection">
+          <dams:CommonNameElement>
+            <mads:elementValue>thale-cress</mads:elementValue>
+          </dams:CommonNameElement>
+        </mads:elementList>
+      </dams:CommonName>
+    </dams:commonName>
+    <dams:note>
+      <dams:Note>
+        <dams:displayLabel>sample number</dams:displayLabel>
+        <dams:type>identifier</dams:type>
+        <rdf:value>PPTU04WT-027D</rdf:value>
+      </dams:Note>
+    </dams:note>
+   
+    <dams:copyright>
+      <dams:Copyright>
+        <dams:copyrightStatus>Public domain</dams:copyrightStatus>
+        <dams:copyrightJurisdiction>us</dams:copyrightJurisdiction>
+      </dams:Copyright>
+    </dams:copyright>
+    <dams:otherRights rdf:resource="http://library.ucsd.edu/ark:/20775/xx58718348"/>
+    <dams:provenanceCollection rdf:resource="http://library.ucsd.edu/ark:/20775/xx91824453"/>
+
+    <dams:hasComponent rdf:resource="http://library.ucsd.edu/ark:/20775/xx99999999/3"/>
+    <dams:hasComponent rdf:resource="http://library.ucsd.edu/ark:/20775/xx99999999/4"/>
+
+  </dams:Object>
+</rdf:RDF>


### PR DESCRIPTION
Fixes #415   ; refs #415

Add restricted view info for metadata-only complex object view.

@ucsdlib/developers - please review
