### PR TITLE
Only enable New Relic agent in Production

### DIFF
--- a/config/newrelic.yml
+++ b/config/newrelic.yml
@@ -19,7 +19,7 @@ common: &default_settings
   app_name: damspas
 
   # To disable the agent regardless of other settings, uncomment the following:
-  # agent_enabled: false
+  agent_enabled: false
 
   # Logging level for log/newrelic_agent.log
   log_level: info
@@ -56,4 +56,5 @@ qa:
 
 production:
   <<: *default_settings
+  agent_enabled: true
   app_name: Production damspas


### PR DESCRIPTION
Changes proposed in this pull request:
* Default new relic agent to be disabled
* Enable new relic agent on production *only*

The reason for this is we're going to start paying for New Relic, and we are charged per host. Which means having Staging, QA, etc. reporting data to New Relic is going to cost us an insanely large amount of money.. So we're going to focus on production. According to their documentation, this should do the trick.

@VivianChu - If this works we'll need to do the same for DMR

@ucsdlib/developers - please review
