### PR TITLE
Remove download link for simple ucsd-only object

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -46,3 +46,9 @@ Metrics/LineLength:
 Style/SafeNavigation:
   Exclude:
     - 'lib/dams/controller_helper.rb'
+
+Metrics/CyclomaticComplexity:
+  Max: 8
+
+Metrics/PerceivedComplexity:
+  Max: 8

--- a/app/helpers/dams_objects_helper.rb
+++ b/app/helpers/dams_objects_helper.rb
@@ -2,7 +2,7 @@ require "base64"
 require "openssl"
 
 module DamsObjectsHelper
-
+  include Dams::ControllerHelper
   #---
     # Openurl, embedded metadata support,
     # Get metadata from solr document, and parsing each field and produce openURL key-encoded value query strings.

--- a/app/views/dams_objects/_admin_download.html.erb
+++ b/app/views/dams_objects/_admin_download.html.erb
@@ -1,14 +1,12 @@
 <div id="etc-menu">
+  <% adl_glyph =  '<i class="glyphicon glyphicon-download-alt"></i>'.html_safe %>
+  <% adl_title = 'Download File' %>
+  <% adl_class = 'adl pull-right' %>
 
-	<% ucsd_local_display = (@document['otherRights_tesim'] != nil && @document['otherRights_tesim'].first.to_s.include?('localDisplay')) ? 'true' : 'false' %>
-	<% adl_glyph =  '<i class="glyphicon glyphicon-download-alt"></i>'.html_safe %>
-	<% adl_title = 'Download File' %>
-	<% adl_class = 'adl pull-right' %>
-
-	<% if can? :update, @document then %>
-	  <%= link_to adl_glyph, downloadFilePath, :rel => 'nofollow', class:adl_class, title:adl_title %>
-	<% elsif ucsd_local_display == 'false' && !downloadDerivativePath.nil?%>
-	  <%= link_to adl_glyph, downloadDerivativePath, :rel => 'nofollow', class:adl_class, title:adl_title %>
-	<% end %>
+  <% if can? :update, @document then %>
+    <%= link_to adl_glyph, downloadFilePath, :rel => 'nofollow', class:adl_class, title:adl_title %>
+  <% elsif can_download?(@document) && !downloadDerivativePath.nil?%>
+    <%= link_to adl_glyph, downloadDerivativePath, :rel => 'nofollow', class:adl_class, title:adl_title %>
+  <% end %>
 
 </div>

--- a/lib/dams/controller_helper.rb
+++ b/lib/dams/controller_helper.rb
@@ -906,5 +906,20 @@ module Dams
     end
     result
   end
+
+    #---
+    # Check to see if an object allows file download
+    #
+    # @return Boolean value
+    #---
+
+    def can_download?(document)
+      local_license = false
+      local_other_rights = document['otherRights_tesim'] && document['otherRights_tesim'].first.to_s.include?('localDisplay') ? true : false
+      if document['resource_type_tesim'] && document['resource_type_tesim'].first.to_s.include?('video')
+        local_license = document['license_tesim'] && document['license_tesim'].first.to_s.include?('localDisplay') ? true : false
+      end
+      !local_other_rights && !local_license
+    end
   end
 end


### PR DESCRIPTION
Fixes #461 

#### Local Checklist
- [x] Tests written and passing locally?
- [x] Code style checked?
- [x] QA-ed locally?
- [x] Rebased with `master` branch?
- [ ] Configuration updated (if needed)?
- [ ] Documentation updated (if needed)?

#### What does this PR do?
Remove download function for UCSD-only video objects

##### Why are we doing this? Any context of related work?
References #461

@ucsdlib/developers - please review
