### PR TITLE
Fixes #467 - Disable file downloading for localDisplay videos/audios and metadataDisplay objects.

### DIFF
--- a/app/controllers/file_controller.rb
+++ b/app/controllers/file_controller.rb
@@ -44,9 +44,7 @@ class FileController < ApplicationController
       authorize! :edit, @solr_doc
     elsif !@solr_doc['read_access_group_ssim'].include?("public")
       authorize! :show, @solr_doc
-      unless can? :edit, @solr_doc
-        raise CanCan::AccessDenied, "User is not allowed to download file: #{field}" unless can_download?(@solr_doc)
-      end
+      raise CanCan::AccessDenied, "Download forbidden: /#{objid}/#{fileid}" unless can?(:edit, @solr_doc) || can_download?(@solr_doc, fileid)
     end
 
     # set headers

--- a/app/controllers/file_controller.rb
+++ b/app/controllers/file_controller.rb
@@ -44,6 +44,9 @@ class FileController < ApplicationController
       authorize! :edit, @solr_doc
     elsif !@solr_doc['read_access_group_ssim'].include?("public")
       authorize! :show, @solr_doc
+      unless can? :edit, @solr_doc
+        raise CanCan::AccessDenied, "User is not allowed to download file: #{field}" unless can_download?(@solr_doc)
+      end
     end
 
     # set headers

--- a/lib/dams/controller_helper.rb
+++ b/lib/dams/controller_helper.rb
@@ -914,12 +914,33 @@ module Dams
     #---
 
     def can_download?(document)
-      local_license = false
-      local_other_rights = document['otherRights_tesim'] && document['otherRights_tesim'].first.to_s.include?('localDisplay') ? true : false
-      if document['resource_type_tesim'] && document['resource_type_tesim'].first.to_s.include?('video')
-        local_license = document['license_tesim'] && document['license_tesim'].first.to_s.include?('localDisplay') ? true : false
+      license = document['license_tesim']
+      other_rights = document['otherRights_tesim']
+      return false if streaming_media_type?(document['resource_type_tesim']) && (local_display?(license) || local_display?(other_rights))
+      !metadata_only_display?(license) || !metadata_only_display?(other_rights)
+    end
+
+    def streaming_media_type?(resource_types)
+      resource_types.each do |t|
+        return true if t.include?('video') || t.include?('sound')
       end
-      !local_other_rights && !local_license
+      false
+    end
+
+    def local_display?(data)
+      return false unless data
+      data.each do |d|
+        return true if d.include?('localDisplay')
+      end
+      false
+    end
+
+    def metadata_only_display?(data)
+      return false unless data
+      data.each do |d|
+        return true if d.include?('metadataDisplay')
+      end
+      false
     end
   end
 end

--- a/lib/dams/controller_helper.rb
+++ b/lib/dams/controller_helper.rb
@@ -899,12 +899,8 @@ module Dams
     end
 
     def metadata_display?(data)
-      result = false
-      return result unless data
-      data.each do |datum|
-        result = true if datum.include?('localDisplay') || datum.include?('metadataDisplay')
-      end
-      result
+      return false if data.blank?
+      data.any? { |t| t.include?('localDisplay') || t.include?('metadataDisplay') }
     end
 
     #---
@@ -914,7 +910,7 @@ module Dams
     #---
     def can_download?(solr_doc, fileid = nil)
       permissions = (Array(solr_doc['license_tesim']) + Array(solr_doc['otherRights_tesim'])).flatten.compact
-      return false if streaming_media_type?(solr_doc['resource_type_tesim']) && local_display?(permissions)
+      return false if streaming_media_type?(solr_doc['resource_type_tesim']) && metadata_display?(permissions)
       metadata_only_display = metadata_only_display?(permissions)
       return !restricted_file?(fileid) if fileid && metadata_only_display
       !metadata_only_display
@@ -927,11 +923,6 @@ module Dams
     def streaming_media_type?(resource_types)
       return false if resource_types.blank?
       resource_types.any? { |t| t.include?('video') || t.include?('sound') }
-    end
-
-    def local_display?(data)
-      return false if data.blank?
-      data.any? { |t| t.include?('localDisplay') }
     end
 
     def metadata_only_display?(data)

--- a/spec/controllers/file_controller_spec.rb
+++ b/spec/controllers/file_controller_spec.rb
@@ -1,0 +1,516 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'net/http'
+require 'json'
+
+# rubocop:disable Metrics/BlockLength, Rails/HttpPositionalArguments
+describe FileController do
+  let(:unit) { DamsUnit.create pid: 'xx48484848', name: 'Test Unit', description: 'Description', code: 'tu', uri: 'http://example.com/' }
+  let(:pub_col) { DamsAssembledCollection.create titleValue: 'Sample Assembled Collection', visibility: 'public' }
+  let(:local_col) { DamsAssembledCollection.create titleValue: 'Sample Assembled Collection', visibility: 'public' }
+  let(:license_local) { DamsLicense.create permissionType: 'localDisplay' }
+  let(:otherRights_metadata) { DamsOtherRight.create permissionType: 'metadataDisplay' }
+  let(:otherRights_local) { DamsOtherRight.create permissionType: 'localDisplay' }
+  let(:image_content) { 'R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7==' }
+  let(:jpeg_content) { '/9j/4AAQSkZJRgABAQEAAQABAAD//2gAIAQEAAD8AVN//2Q==' }
+  let(:wav_content) { '//tQxAAAAAAAAAAAAASW5mbwAAAA8AAAACAAACcQCAgICAgICAgVVVVVVVVVVVVVQ==' }
+  let(:mp3_content) { '//tQxAASW5mbwAAAA/8QU34oKC/0FBVTEFNRTMuOTkuNVQ==' }
+  let(:mov_content) { '//tQxAAAAAAAAAAAAAMOVVIDEOVVVVVVVVVVVVVQ==' }
+  let(:mp4_content) { '//tQxAASW5mbwAAAA/MP4VIDEO/0FBVTEFNRTMuOTkuNVQ==' }
+
+  describe 'public object image download' do
+    let(:obj) do
+      DamsObject.create(titleValue: 'Image Test', typeOfResource: 'still image', unitURI: [unit.pid],
+                        copyright_attributes: [{ status: 'Public domain' }], assembledCollectionURI: [pub_col.pid])
+    end
+
+    before do
+      obj.add_file(Base64.decode64(image_content), '_1.tif', 'image_source.tif')
+      obj.add_file(Base64.decode64(jpeg_content), '_2.jpg', 'image_service.jpg')
+      obj.save
+      solr_index obj.pid
+    end
+
+    describe 'curator' do
+      it 'can download the source file' do
+        sign_in User.create!(provider: 'developer')
+        get :show, id: obj.pid, ds: '_1.tif'
+        expect(response).to have_http_status(200)
+      end
+
+      it 'can download the service file' do
+        sign_in User.create!(provider: 'developer')
+        get :show, id: obj.pid, ds: '_2.jpg'
+        expect(response).to have_http_status(200)
+      end
+    end
+
+    describe 'public user' do
+      it 'cannot download the source file' do
+        get :show, id: obj.pid, ds: '_1.tif'
+        expect(response).to have_http_status(403)
+      end
+
+      it 'can download service file' do
+        get :show, id: obj.pid, ds: '_2.jpg'
+        expect(response).to have_http_status(200)
+      end
+    end
+
+    describe 'campus user' do
+      it 'cannot download the source file' do
+        sign_in_anonymous '137.110.0.1'
+        get :show, id: obj.pid, ds: '_1.tif'
+        expect(response).to have_http_status(403)
+      end
+
+      it 'can download the service file' do
+        sign_in_anonymous '137.110.0.1'
+        get :show, id: obj.pid, ds: '_2.jpg'
+        expect(response).to have_http_status(200)
+      end
+    end
+  end
+
+  describe 'UCSD IP/metadata-only file download' do
+    let(:obj) do
+      DamsObject.create(titleValue: 'Image Test', typeOfResource: 'still image',
+                        unitURI: [unit.pid], copyright_attributes: [{ status: 'Unknown' }], assembledCollectionURI: [local_col.pid])
+    end
+
+    before do
+      obj.otherRightsURI = otherRights_metadata.pid
+      obj.add_file(Base64.decode64(image_content), '_1.tif', 'image_source.tif')
+      obj.add_file(Base64.decode64(jpeg_content), '_2.jpg', 'image_service.jpg')
+      obj.save
+      solr_index obj.pid
+    end
+
+    describe 'curator' do
+      it 'can download the source file' do
+        sign_in User.create!(provider: 'developer')
+        get :show, id: obj.pid, ds: '_1.tif'
+        expect(response).to have_http_status(200)
+      end
+
+      it 'can download the service file' do
+        sign_in User.create!(provider: 'developer')
+        get :show, id: obj.pid, ds: '_2.jpg'
+        expect(response).to have_http_status(200)
+      end
+    end
+
+    describe 'public user' do
+      it 'cannot download the source file' do
+        get :show, id: obj.pid, ds: '_1.tif'
+        expect(response).to have_http_status(403)
+      end
+
+      it 'cannot download service file' do
+        get :show, id: obj.pid, ds: '_2.jpg'
+        expect(response).to have_http_status(403)
+      end
+    end
+
+    describe 'campus user' do
+      it 'cannot download the source file' do
+        sign_in_anonymous '137.110.0.1'
+        get :show, id: obj.pid, ds: '_1.tif'
+        expect(response).to have_http_status(403)
+      end
+
+      it 'cannot download the service file' do
+        sign_in_anonymous '137.110.0.1'
+        get :show, id: obj.pid, ds: '_2.jpg'
+        expect(response).to have_http_status(403)
+      end
+    end
+  end
+
+  describe 'public metadata-display file download' do
+    let(:obj) do
+      DamsObject.create(titleValue: 'Image Test', typeOfResource: 'still image',
+                        unitURI: [unit.pid], copyright_attributes: [{ status: 'Unknown' }], assembledCollectionURI: [pub_col.pid])
+    end
+
+    before do
+      obj.otherRightsURI = otherRights_metadata.pid
+      obj.add_file(Base64.decode64(image_content), '_1.tif', 'image_source.tif')
+      obj.add_file(Base64.decode64(jpeg_content), '_2.jpg', 'image_service.jpg')
+      obj.save
+      solr_index obj.pid
+    end
+
+    describe 'curator' do
+      it 'can download the source file' do
+        sign_in User.create!(provider: 'developer')
+        get :show, id: obj.pid, ds: '_1.tif'
+        expect(response).to have_http_status(200)
+      end
+
+      it 'can download the service file' do
+        sign_in User.create!(provider: 'developer')
+        get :show, id: obj.pid, ds: '_2.jpg'
+        expect(response).to have_http_status(200)
+      end
+    end
+
+    describe 'public user' do
+      it 'cannot download the source file' do
+        get :show, id: obj.pid, ds: '_1.tif'
+        expect(response).to have_http_status(403)
+      end
+
+      it 'cannot download service file' do
+        get :show, id: obj.pid, ds: '_2.jpg'
+        expect(response).to have_http_status(403)
+      end
+    end
+
+    describe 'campus user' do
+      it 'cannot download the source file' do
+        sign_in_anonymous '137.110.0.1'
+        get :show, id: obj.pid, ds: '_1.tif'
+        expect(response).to have_http_status(403)
+      end
+
+      it 'cannot download the service file' do
+        sign_in_anonymous '137.110.0.1'
+        get :show, id: obj.pid, ds: '_2.jpg'
+        expect(response).to have_http_status(403)
+      end
+    end
+  end
+
+  describe 'OtherRights localDisplay file download' do
+    let(:obj) do
+      DamsObject.create(titleValue: 'Image Test', typeOfResource: 'still image',
+                        unitURI: [unit.pid], copyright_attributes: [{ status: 'Unknown' }], assembledCollectionURI: [local_col.pid])
+    end
+
+    before do
+      obj.otherRightsURI = otherRights_local.pid
+      obj.add_file(Base64.decode64(image_content), '_1.tif', 'image_source.tif')
+      obj.add_file(Base64.decode64(jpeg_content), '_2.jpg', 'image_service.jpg')
+      obj.save
+      solr_index obj.pid
+    end
+
+    describe 'curator' do
+      it 'can download the source file' do
+        sign_in User.create!(provider: 'developer')
+        get :show, id: obj.pid, ds: '_1.tif'
+        expect(response).to have_http_status(200)
+      end
+
+      it 'can download the service file' do
+        sign_in User.create!(provider: 'developer')
+        get :show, id: obj.pid, ds: '_2.jpg'
+        expect(response).to have_http_status(200)
+      end
+    end
+
+    describe 'public user' do
+      it 'cannot download the source file' do
+        get :show, id: obj.pid, ds: '_1.tif'
+        expect(response).to have_http_status(403)
+      end
+
+      it 'cannot download service file' do
+        get :show, id: obj.pid, ds: '_2.jpg'
+        expect(response).to have_http_status(403)
+      end
+    end
+
+    describe 'campus user' do
+      it 'cannot download the source file' do
+        sign_in_anonymous '137.110.0.1'
+        get :show, id: obj.pid, ds: '_1.tif'
+        expect(response).to have_http_status(403)
+      end
+
+      it 'can download the service file' do
+        sign_in_anonymous '137.110.0.1'
+        get :show, id: obj.pid, ds: '_2.jpg'
+        expect(response).to have_http_status(200)
+      end
+    end
+  end
+
+  describe 'License localDisplay file download' do
+    let(:obj) do
+      DamsObject.create(titleValue: 'Image Test', typeOfResource: 'still image',
+                        unitURI: [unit.pid], copyright_attributes: [{ status: 'Unknown' }], assembledCollectionURI: [local_col.pid])
+    end
+
+    before do
+      obj.licenseURI = license_local.pid
+      obj.add_file(Base64.decode64(image_content), '_1.tif', 'image_source.tif')
+      obj.add_file(Base64.decode64(jpeg_content), '_2.jpg', 'image_service.jpg')
+      obj.save
+      solr_index obj.pid
+    end
+
+    describe 'curator' do
+      it 'can download the source file' do
+        sign_in User.create!(provider: 'developer')
+        get :show, id: obj.pid, ds: '_1.tif'
+        expect(response).to have_http_status(200)
+      end
+
+      it 'can download the service file' do
+        sign_in User.create!(provider: 'developer')
+        get :show, id: obj.pid, ds: '_2.jpg'
+        expect(response).to have_http_status(200)
+      end
+    end
+
+    describe 'public user' do
+      it 'cannot download the source file' do
+        get :show, id: obj.pid, ds: '_1.tif'
+        expect(response).to have_http_status(403)
+      end
+
+      it 'cannot download service file' do
+        get :show, id: obj.pid, ds: '_2.jpg'
+        expect(response).to have_http_status(403)
+      end
+    end
+
+    describe 'campus user' do
+      it 'cannot download the source file' do
+        sign_in_anonymous '137.110.0.1'
+        get :show, id: obj.pid, ds: '_1.tif'
+        expect(response).to have_http_status(403)
+      end
+
+      it 'can download the image file' do
+        sign_in_anonymous '137.110.0.1'
+        get :show, id: obj.pid, ds: '_2.jpg'
+        expect(response).to have_http_status(200)
+      end
+    end
+  end
+
+  describe 'License localDisplay audio download' do
+    let(:obj) do
+      DamsObject.create(titleValue: 'MP3 Test', typeOfResource: 'sound recording',
+                        unitURI: [unit.pid], copyright_attributes: [{ status: 'Unknown' }])
+    end
+
+    before do
+      obj.licenseURI = license_local.pid
+      obj.add_file(Base64.decode64(mp3_content), '_1.wav', 'audio_source.wav')
+      obj.add_file(Base64.decode64(mp3_content), '_2.mp3', 'audio_service.mp3')
+      obj.save
+      solr_index obj.pid
+    end
+
+    describe 'curator download' do
+      it 'can download the master file' do
+        sign_in User.create!(provider: 'developer')
+        get :show, id: obj.pid, ds: '_1.wav'
+        expect(response).to have_http_status(200)
+      end
+
+      it 'can download the mp3 derivative' do
+        sign_in User.create!(provider: 'developer')
+        get :show, id: obj.pid, ds: '_2.mp3'
+        expect(response).to have_http_status(200)
+      end
+    end
+
+    describe 'public download' do
+      it 'cannot download the master file' do
+        get :show, id: obj.pid, ds: '_1.wav'
+        expect(response).to have_http_status(403)
+      end
+
+      it 'cannot download the mp3 derivative' do
+        get :show, id: obj.pid, ds: '_2.mp3'
+        expect(response).to have_http_status(403)
+      end
+    end
+
+    describe 'campus download' do
+      it 'cannot download the master file' do
+        sign_in_anonymous '137.110.0.1'
+        get :show, id: obj.pid, ds: '_1.wav'
+        expect(response).to have_http_status(403)
+      end
+
+      it 'cannot download the mp3 derivative' do
+        sign_in_anonymous '137.110.0.1'
+        get :show, id: obj.pid, ds: '_2.mp3'
+        expect(response).to have_http_status(403)
+      end
+    end
+  end
+
+  describe 'OtherRights localDisplay audio download' do
+    let(:obj) do
+      DamsObject.create(titleValue: 'MP3 Test', typeOfResource: 'sound recording',
+                        unitURI: [unit.pid], copyright_attributes: [{ status: 'Unknown' }])
+    end
+
+    before do
+      obj.otherRightsURI = otherRights_local.pid
+      obj.add_file(Base64.decode64(mp3_content), '_1.wav', 'audio_source.wav')
+      obj.add_file(Base64.decode64(mp3_content), '_2.mp3', 'audio_service.mp3')
+      obj.save
+      solr_index obj.pid
+    end
+
+    describe 'curator download' do
+      it 'can download the master file' do
+        sign_in User.create!(provider: 'developer')
+        get :show, id: obj.pid, ds: '_1.wav'
+        expect(response).to have_http_status(200)
+      end
+
+      it 'can download the mp3 derivative' do
+        sign_in User.create!(provider: 'developer')
+        get :show, id: obj.pid, ds: '_2.mp3'
+        expect(response).to have_http_status(200)
+      end
+    end
+
+    describe 'public download' do
+      it 'cannot download the master file' do
+        get :show, id: obj.pid, ds: '_1.wav'
+        expect(response).to have_http_status(403)
+      end
+
+      it 'cannot download the mp3 derivative' do
+        get :show, id: obj.pid, ds: '_2.mp3'
+        expect(response).to have_http_status(403)
+      end
+    end
+
+    describe 'campus download' do
+      it 'cannot download the master file' do
+        sign_in_anonymous '137.110.0.1'
+        get :show, id: obj.pid, ds: '_1.wav'
+        expect(response).to have_http_status(403)
+      end
+
+      it 'cannot download the mp3 derivative' do
+        sign_in_anonymous '137.110.0.1'
+        get :show, id: obj.pid, ds: '_2.mp3'
+        expect(response).to have_http_status(403)
+      end
+    end
+  end
+
+  describe 'License localDisplay video download' do
+    let(:obj) do
+      DamsObject.create(titleValue: 'Video Test', typeOfResource: 'video',
+                        unitURI: [unit.pid], copyright_attributes: [{ status: 'Unknown' }])
+    end
+
+    before do
+      obj.licenseURI = license_local.pid
+      obj.add_file(Base64.decode64(mov_content), '_1.mov', 'audio_source.mov')
+      obj.add_file(Base64.decode64(mp4_content), '_2.mp4', 'audio_service.mp4')
+      obj.save
+      solr_index obj.pid
+    end
+
+    describe 'curator download' do
+      it 'can download the master file' do
+        sign_in User.create!(provider: 'developer')
+        get :show, id: obj.pid, ds: '_1.mov'
+        expect(response).to have_http_status(200)
+      end
+
+      it 'can download the mp4 derivative' do
+        sign_in User.create!(provider: 'developer')
+        get :show, id: obj.pid, ds: '_2.mp4'
+        expect(response).to have_http_status(200)
+      end
+    end
+
+    describe 'public download' do
+      it 'cannot download the master file' do
+        get :show, id: obj.pid, ds: '_1.mov'
+        expect(response).to have_http_status(403)
+      end
+
+      it 'cannot download the mp4 derivative' do
+        get :show, id: obj.pid, ds: '_2.mp4'
+        expect(response).to have_http_status(403)
+      end
+    end
+
+    describe 'campus download' do
+      it 'cannot download the master file' do
+        sign_in_anonymous '137.110.0.1'
+        get :show, id: obj.pid, ds: '_1.mov'
+        expect(response).to have_http_status(403)
+      end
+
+      it 'cannot download the mp4 derivative' do
+        sign_in_anonymous '137.110.0.1'
+        get :show, id: obj.pid, ds: '_2.mp4'
+        expect(response).to have_http_status(403)
+      end
+    end
+  end
+
+  describe 'OtherRights localDisplay video download' do
+    let(:obj) do
+      DamsObject.create(titleValue: 'Video Test', typeOfResource: 'video',
+                        unitURI: [unit.pid], copyright_attributes: [{ status: 'Unknown' }])
+    end
+
+    before do
+      obj.otherRightsURI = otherRights_local.pid
+      obj.add_file(Base64.decode64(mov_content), '_1.mov', 'audio_source.mov')
+      obj.add_file(Base64.decode64(mp4_content), '_2.mp4', 'audio_service.mp4')
+      obj.save
+      solr_index obj.pid
+    end
+
+    describe 'curator download' do
+      it 'can download the master file' do
+        sign_in User.create!(provider: 'developer')
+        get :show, id: obj.pid, ds: '_1.mov'
+        expect(response).to have_http_status(200)
+      end
+
+      it 'can download the mp4 derivative' do
+        sign_in User.create!(provider: 'developer')
+        get :show, id: obj.pid, ds: '_2.mp4'
+        expect(response).to have_http_status(200)
+      end
+    end
+
+    describe 'public download' do
+      it 'cannot download the master file' do
+        get :show, id: obj.pid, ds: '_1.mov'
+        expect(response).to have_http_status(403)
+      end
+
+      it 'cannot download the mp4 derivative' do
+        get :show, id: obj.pid, ds: '_2.mp4'
+        expect(response).to have_http_status(403)
+      end
+    end
+
+    describe 'campus download' do
+      it 'cannot download the master file' do
+        sign_in_anonymous '137.110.0.1'
+        get :show, id: obj.pid, ds: '_1.mov'
+        expect(response).to have_http_status(403)
+      end
+
+      it 'cannot download the mp4 derivative' do
+        sign_in_anonymous '137.110.0.1'
+        get :show, id: obj.pid, ds: '_2.mp4'
+        expect(response).to have_http_status(403)
+      end
+    end
+  end
+end
+# rubocop:enable Rails/HttpPositionalArguments, Metrics/BlockLength

--- a/spec/controllers/file_controller_spec.rb
+++ b/spec/controllers/file_controller_spec.rb
@@ -579,5 +579,124 @@ describe FileController do
       end
     end
   end
+
+  describe 'OtherRights metadataDisplay audio download' do
+    let(:obj) do
+      DamsObject.create(titleValue: 'MP3 Test', typeOfResource: 'sound recording',
+                        unitURI: [unit.pid], copyright_attributes: [{ status: 'Unknown' }])
+    end
+
+    before do
+      obj.assembledCollectionURI = [local_col.pid]
+      obj.otherRightsURI = otherRights_metadata.pid
+      obj.add_file(Base64.decode64(mp3_content), '_1.wav', 'audio_source.wav')
+      obj.add_file(Base64.decode64(mp3_content), '_2.mp3', 'audio_service.mp3')
+      obj.save
+      solr_index obj.pid
+    end
+
+    after do
+      obj.delete
+    end
+
+    describe 'curator download' do
+      it 'can download the master file' do
+        sign_in User.create!(provider: 'developer')
+        get :show, id: obj.pid, ds: '_1.wav'
+        expect(response).to have_http_status(200)
+      end
+
+      it 'can download the mp3 derivative' do
+        sign_in User.create!(provider: 'developer')
+        get :show, id: obj.pid, ds: '_2.mp3'
+        expect(response).to have_http_status(200)
+      end
+    end
+
+    describe 'public download' do
+      it 'cannot download the master file' do
+        get :show, id: obj.pid, ds: '_1.wav'
+        expect(response).to have_http_status(403)
+      end
+
+      it 'cannot download the mp3 derivative' do
+        get :show, id: obj.pid, ds: '_2.mp3'
+        expect(response).to have_http_status(403)
+      end
+    end
+
+    describe 'campus download' do
+      it 'cannot download the master file' do
+        sign_in_anonymous '132.239.0.3'
+        get :show, id: obj.pid, ds: '_1.wav'
+        expect(response).to have_http_status(403)
+      end
+
+      it 'cannot download the mp3 derivative' do
+        sign_in_anonymous '132.239.0.3'
+        get :show, id: obj.pid, ds: '_2.mp3'
+        expect(response).to have_http_status(403)
+      end
+    end
+  end
+  describe 'OtherRights metadataDisplay video download' do
+    let(:obj) do
+      DamsObject.create(titleValue: 'Video Test', typeOfResource: 'video',
+                        unitURI: [unit.pid], copyright_attributes: [{ status: 'Unknown' }])
+    end
+
+    before do
+      obj.assembledCollectionURI = [local_col.pid]
+      obj.otherRightsURI = otherRights_metadata.pid
+      obj.add_file(Base64.decode64(mov_content), '_1.mov', 'audio_source.mov')
+      obj.add_file(Base64.decode64(mp4_content), '_2.mp4', 'audio_service.mp4')
+      obj.save
+      solr_index obj.pid
+    end
+
+    after do
+      obj.delete
+    end
+
+    describe 'curator download' do
+      it 'can download the master file' do
+        sign_in User.create!(provider: 'developer')
+        get :show, id: obj.pid, ds: '_1.mov'
+        expect(response).to have_http_status(200)
+      end
+
+      it 'can download the mp4 derivative' do
+        sign_in User.create!(provider: 'developer')
+        get :show, id: obj.pid, ds: '_2.mp4'
+        expect(response).to have_http_status(200)
+      end
+    end
+
+    describe 'public download' do
+      it 'cannot download the master file' do
+        get :show, id: obj.pid, ds: '_1.mov'
+        expect(response).to have_http_status(403)
+      end
+
+      it 'cannot download the mp4 derivative' do
+        get :show, id: obj.pid, ds: '_2.mp4'
+        expect(response).to have_http_status(403)
+      end
+    end
+
+    describe 'campus download' do
+      it 'cannot download the master file' do
+        sign_in_anonymous '132.239.0.3'
+        get :show, id: obj.pid, ds: '_1.mov'
+        expect(response).to have_http_status(403)
+      end
+
+      it 'cannot download the mp4 derivative' do
+        sign_in_anonymous '132.239.0.3'
+        get :show, id: obj.pid, ds: '_2.mp4'
+        expect(response).to have_http_status(403)
+      end
+    end
+  end
 end
 # rubocop:enable Rails/HttpPositionalArguments, Metrics/BlockLength


### PR DESCRIPTION
Fixes #467

#### Local Checklist
- [x] Tests written and passing locally?
- [x] Code style checked?
- [ ] QA-ed locally?
- [x] Rebased with `master` branch?
- [ ] Configuration updated (if needed)?
- [ ] Documentation updated (if needed)?

#### What does this PR do?
Disable file downloading for localDisplay videos/audios and metadataDisplay objects, while allowing campus users to download localDisplay images.

##### Why are we doing this? Any context of related work?
References #466, #467 

@ucsdlib/developers - please review
