### PR TITLE
Add different access text for mixed objects metadata-only collection

### DIFF
--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -325,7 +325,7 @@ class CatalogController < ApplicationController
     solr_params[:fq] = ["{!join from=collections_tesim to=id}#{metadata_only_fquery}"]
     response = raw_solr(solr_params.merge(params))
     response.docs.each do |doc|
-      mix_obj = mix_objects?(doc['id_t'])
+      mix_obj = mix_objects?(doc['id_t'], metadata_obj_count(doc['id_t']))
       val = mix_obj ? "#{doc['id_t']}#{mix_obj}" : doc['id_t']
       meta_colls << val
     end

--- a/app/controllers/dams_resource_controller.rb
+++ b/app/controllers/dams_resource_controller.rb
@@ -42,8 +42,8 @@ class DamsResourceController < ApplicationController
     if models.include?("DamsAssembledCollection") || models.include?("DamsProvenanceCollection") || models.include?("DamsProvenanceCollectionPart") 
         collection_solr_params = build_params("collections_tesim:#{params[:id]}", metadata_only_fquery)
         collection_response = raw_solr(collection_solr_params)
-        @metadata_only = !collection_response.response['numFound'].zero?
-        @mix_objects = mix_objects?(params[:id], collection_response.response['numFound']) if @metadata_only
+        @metadata_only = collection_response.response['numFound'].to_i > 0
+        @mix_objects = mix_objects?(params[:id], collection_response.response['numFound'].to_i)
         
         facet_collection_params = { :f=>{"collection_sim"=>"#{@document['title_tesim'].first.to_s}"}, :id=>params[:id], :rows => 0 }
         apply_gated_discovery( facet_collection_params, nil )

--- a/app/helpers/catalog_helper.rb
+++ b/app/helpers/catalog_helper.rb
@@ -96,8 +96,9 @@ module CatalogHelper
     access_group = document['read_access_group_ssim'] # "public" > "local" > "dams-curator" == "dams-rci" == default
     view_access = 'Curator Only'
     if access_group
-
-      if metadata_colls.include?(document['id']) || metadata_display?(rights_data(document))
+      if metadata_colls.include?("#{document['id']}true")
+        view_access = 'Some items restricted'
+      elsif metadata_colls.include?(document['id']) || metadata_display?(rights_data(document))
         view_access = 'Restricted View'
       elsif access_group.include?('public')
         view_access = nil

--- a/app/views/shared/fields/_access_control_level.html.erb
+++ b/app/views/shared/fields/_access_control_level.html.erb
@@ -6,7 +6,9 @@
 
 	if accessGroup != nil
 
-                if @metadata_only
+                if @mix_objects
+                    viewAccess = 'Some items restricted'
+                elsif @metadata_only
                     viewAccess = 'Restricted View'
 		elsif accessGroup.include?('public')
 		    viewAccess = :public	  

--- a/lib/dams/controller_helper.rb
+++ b/lib/dams/controller_helper.rb
@@ -905,12 +905,12 @@ module Dams
 
     def total_count(collection_id)
       solr_params = build_params("collections_tesim:#{collection_id}")
-      raw_solr(solr_params).response['numFound']
+      raw_solr(solr_params).response['numFound'].to_i
     end
 
     def metadata_obj_count(collection_id)
       solr_params = build_params("collections_tesim:#{collection_id}", metadata_only_fquery)
-      raw_solr(solr_params).response['numFound']
+      raw_solr(solr_params).response['numFound'].to_i
     end
 
     def build_params(query, fquery = nil)
@@ -928,9 +928,8 @@ module Dams
       solr_response
     end
 
-    def mix_objects?(collection_id, obj_count = nil)
-      obj_count = metadata_obj_count(collection_id) if obj_count.nil?
-      return false unless obj_count && !obj_count.zero?
+    def mix_objects?(collection_id, obj_count)
+      return false unless obj_count && obj_count > 0
       total_count(collection_id) > obj_count
     end
 

--- a/lib/dams/controller_helper.rb
+++ b/lib/dams/controller_helper.rb
@@ -929,7 +929,7 @@ module Dams
     end
 
     def mix_objects?(collection_id, obj_count)
-      return false unless obj_count && obj_count > 0
+      return false unless obj_count && obj_count.positive?
       total_count(collection_id) > obj_count
     end
 

--- a/spec/features/dams_object_spec.rb
+++ b/spec/features/dams_object_spec.rb
@@ -980,7 +980,6 @@ describe "User wants to view simple object for local metadata-only collection" d
 
   scenario 'public user should see Restricted View access text and no download link' do
     visit dams_object_path @metadataOnlyObj.pid
-    #puts page.body
     expect(page).to have_content('Restricted View')
     expect(page).to have_selector('div.restricted-notice', text: @restricted_note)
     expect(page).to_not have_link('', href:"/object/#{@metadataOnlyObj.id}/_1.mp4/download")


### PR DESCRIPTION
Fixes #483 

#### Local Checklist
- [x] Tests written and passing locally?
- [x] Code style checked?
- [x] QA-ed locally?
- [x] Rebased with `master` branch?
- [ ] Configuration updated (if needed)?
- [ ] Documentation updated (if needed)?

#### What does this PR do?
 
It will display "Some items restricted" access type for collection with mixed objects.

##### Why are we doing this? Any context of related work?

References #483 

#### Screenshots

![mixedcollection](https://user-images.githubusercontent.com/1864660/42911466-df70062c-8a9f-11e8-81e5-76a213a89ebc.png)




@ucsdlib/developers - please review
