### PR TITLE
Fixes #464 - Add support of facet_default_uri for search result page …

### DIFF
--- a/app/helpers/catalog_helper.rb
+++ b/app/helpers/catalog_helper.rb
@@ -58,6 +58,10 @@ module CatalogHelper
     return add_facet_params(field_string, field).merge!({"controller" => "catalog", :action=> "index"})
   end
 
+  def facet_default_uri(field, field_string)
+    return add_facet_params(field_string, field).merge!({"controller" => "catalog", :action=> "index", :sort=>"title_ssi asc"})
+  end
+
   #override of blacklight helper function: 
   # https://github.com/projectblacklight/blacklight/blob/master/app/helpers/blacklight/blacklight_helper_behavior.rb#L353
   # uses a semi-colon delimiter in for search result field values

--- a/app/views/catalog/_sort_widget.html.erb
+++ b/app/views/catalog/_sort_widget.html.erb
@@ -9,7 +9,7 @@
 
     <ul class="dropdown-menu">
       <%- blacklight_config.sort_fields.each do |sort_key, field| %>
-        <li><%= link_to(field.label, url_for(params_for_search(:sort => sort_key))) %></li>
+        <li><%= link_to(field.label, url_for(params_for_search(:sort => sort_key))) %></li>        
       <%- end -%>
     </ul>
 

--- a/app/views/dams_collections/show.html.erb
+++ b/app/views/dams_collections/show.html.erb
@@ -23,7 +23,7 @@
   </div>
   <%# Collection controls %>
   <% if @object_count > 0 %>
-    <%= link_to "<i class='icon-eye-open icon-white'></i> View Collection Items".html_safe, facet_uri(@collection_title,'collection_sim'), :class => 'btn btn-large btn-inverse btn-block' %>
+    <%= link_to "<i class='icon-eye-open icon-white'></i> View Collection Items".html_safe, facet_default_uri(@collection_title,'collection_sim'), :class => 'btn btn-large btn-inverse btn-block' %>
     <div class="well collections-search-box"><%= render :partial => 'search' %></div>
   <% else %>
     <p class="alert alert-phone alert-no-dismiss"><%=no_collection_items_notice%></p>
@@ -50,7 +50,7 @@
       </div>
       <%# Collection controls %>
       <% if @object_count > 0 %>
-        <%= link_to "<i class='icon-eye-open icon-white'></i> View Collection Items".html_safe, facet_uri(@collection_title,'collection_sim'), :class => 'btn btn-large btn-inverse btn-block' %>
+        <%= link_to "<i class='icon-eye-open icon-white'></i> View Collection Items".html_safe, facet_default_uri(@collection_title,'collection_sim'), :class => 'btn btn-large btn-inverse btn-block' %>
         <div class="well collections-search-box"><%= render :partial => 'search' %></div>
       <% else %>
         <p class="alert alert-no-dismiss"><%=no_collection_items_notice%></p>

--- a/spec/features/dams_collections_spec.rb
+++ b/spec/features/dams_collections_spec.rb
@@ -81,7 +81,6 @@ feature 'Visitor wants to look at collections' do
     visit dams_collections_path({:per_page=>100})
     expect(page).to have_content('Access: Curator Only')
   end
-
 end
 
 feature 'Visitor wants to look at the collection search results view with no issued date' do
@@ -102,7 +101,6 @@ feature 'Visitor wants to look at the collection search results view with no iss
     expect(page).to have_selector("ul.dams-search-results-fields:first li span", :text => '1961-1978')
     expect(page).to have_no_content('1000-2015')     
   end
-
 end
 
 feature 'Visitor wants to see the collection record' do
@@ -119,11 +117,13 @@ feature 'Visitor wants to see the collection record' do
     @unit.delete
     @commonName.delete
   end 
+
   scenario 'should see the related resource with no URI' do
     visit dams_collection_path("#{@provCollection.pid}")
     expect(page).to have_content('The physical materials are held at UC San Diego Library')
     expect(page).not_to have_link('The physical materials are held at UC San Diego Library', {href: ''})    
   end
+
   scenario 'should see the names in order' do
     visit dams_collection_path("#{@provCollection.pid}")
     expect(page).to have_selector("div.span8 dl dt[1]", :text => 'Principal Investigator')  
@@ -131,7 +131,6 @@ feature 'Visitor wants to see the collection record' do
     expect(page).to have_selector("div.span8 dl dt[5]", :text => 'Creator')
     expect(page).to have_selector("div.span8 dl dt[7]", :text => 'Author')
     expect(page).to have_selector("div.span8 dl dt[9]", :text => 'Contributors')
-        
   end
 
   scenario 'should not see access control information (public)' do
@@ -341,6 +340,13 @@ feature 'Visitor wants to look at the collection item view search results' do
     expect(page).to_not have_content("<a href=\"http://library.ucsd.edu/dc/collection/<span class='search-highlight'>#{@aCollection.pid}</span>\">")
   end
 
+  scenario 'should see the search result page default sort is title after click "View Collection Items"' do
+    visit dams_collection_path("#{@aCollection.pid}")
+    first(:link, "View Collection Items").click
+    
+    expect(page).to have_content("Sort: title")
+    expect(page).to_not have_content("Sort: relevance")
+  end
 end
 
 


### PR DESCRIPTION
…when using View Collection Items.

Fixes #464

#### Local Checklist
- [x] Tests written and passing locally?
- [x] Code style checked?
- [x] QA-ed locally?

#### What does this PR do?
When selecting "View Collection Items" from a collection landing page, the result list that the user is taken to defaults to "sort by Title"

@ucsdlib/developers - please review
