### PR TITLE
Remove host, username, password from db defaults

### DIFF
--- a/config/database.yml
+++ b/config/database.yml
@@ -6,9 +6,6 @@
 default: &default
   adapter: postgresql
   encoding: unicode
-  host: <%= ENV.fetch('APPS_DHH_DEV_DB') %>
-  username: <%= ENV.fetch('APPS_DHH_DEV_DB_USER') %>
-  password: <%= ENV.fetch('APPS_DHH_DEV_DB_PASS') %>
   pool: 5
 variables:
   statement_timeout: 5000
@@ -16,6 +13,7 @@ variables:
 development:
   <<: *default
   database: damspas_development
+  host: <%= ENV.fetch('APPS_DHH_DEV_DB') %>
   username: <%= ENV.fetch('APPS_DHH_DEV_DB_USER') {'dams'}%>
   password: <%= ENV.fetch('APPS_DHH_DEV_DB_PASS') {'dams'}%>
 
@@ -60,6 +58,7 @@ demo:
 test:
   <<: *default
   database: damspas_test
+  host: <%= ENV.fetch('APPS_DHH_DEV_DB') %>
   username: <%= ENV.fetch('APPS_DHH_DEV_DB_USER') {'dams'}%>
   password: <%= ENV.fetch('APPS_DHH_DEV_DB_PASS') {'dams'}%>
 


### PR DESCRIPTION
#### Local Checklist
- [x] QA-ed locally?
- [x] Rebased with `master` branch?

#### What does this PR do?
Removes the `ENV` fetching of environment variables from the `default` database environment block, and ensure that each environment handles these individually.

##### Why are we doing this? Any context of related work?
These default `DEV` ENV variables won't exist in all environments, and thus the fetch
calls will fail. Remove, and allow individual environments to specify as
needed.

@ucsdlib/developers - please review
