### PR TITLE
Fixes #467 - Allow UCSD local users to download videos icons for UCSD IP/metadata-only collections.

### DIFF
--- a/lib/dams/controller_helper.rb
+++ b/lib/dams/controller_helper.rb
@@ -940,7 +940,7 @@ module Dams
     #---
     def can_download?(solr_doc, fileid = nil)
       permissions = (Array(solr_doc['license_tesim']) + Array(solr_doc['otherRights_tesim'])).flatten.compact
-      return false if streaming_media_type?(solr_doc['resource_type_tesim']) && metadata_display?(permissions)
+      return false if streaming_media_type?(solr_doc['resource_type_tesim'], fileid) && metadata_display?(permissions)
       metadata_only_display = metadata_only_display?(permissions)
       return !restricted_file?(fileid) if fileid && metadata_only_display
       !metadata_only_display
@@ -950,9 +950,11 @@ module Dams
       fileid && fileid.include?('_2.jpg')
     end
 
-    def streaming_media_type?(resource_types)
+    def streaming_media_type?(resource_types, fileid = nil)
       return false if resource_types.blank?
-      resource_types.any? { |t| t.include?('video') || t.include?('sound') }
+      video_type = resource_types.any? { |t| t.include?('video') || t.include?('sound') }
+      return video_type unless video_type && fileid
+      fileid.end_with?('.mp4', '.mp3')
     end
 
     def metadata_only_display?(data)

--- a/spec/controllers/file_controller_spec.rb
+++ b/spec/controllers/file_controller_spec.rb
@@ -471,6 +471,7 @@ describe FileController do
       obj.licenseURI = license_local.pid
       obj.add_file(Base64.decode64(mov_content), '_1.mov', 'audio_source.mov')
       obj.add_file(Base64.decode64(mp4_content), '_2.mp4', 'audio_service.mp4')
+      obj.add_file(Base64.decode64(jpeg_content), '_4.jpg', 'image_icon.jpg')
       obj.save
       solr_index obj.pid
     end
@@ -491,6 +492,12 @@ describe FileController do
         get :show, id: obj.pid, ds: '_2.mp4'
         expect(response).to have_http_status(200)
       end
+
+      it 'can download the image icon' do
+        sign_in User.create!(provider: 'developer')
+        get :show, id: obj.pid, ds: '_4.jpg'
+        expect(response).to have_http_status(200)
+      end
     end
 
     describe 'public download' do
@@ -501,6 +508,11 @@ describe FileController do
 
       it 'cannot download the mp4 derivative' do
         get :show, id: obj.pid, ds: '_2.mp4'
+        expect(response).to have_http_status(403)
+      end
+
+      it 'cannot download the image icon' do
+        get :show, id: obj.pid, ds: '_4.jpg'
         expect(response).to have_http_status(403)
       end
     end
@@ -516,6 +528,12 @@ describe FileController do
         sign_in_anonymous '132.239.0.3'
         get :show, id: obj.pid, ds: '_2.mp4'
         expect(response).to have_http_status(403)
+      end
+
+      it 'can download the image icon' do
+        sign_in_anonymous '132.239.0.3'
+        get :show, id: obj.pid, ds: '_4.jpg'
+        expect(response).to have_http_status(200)
       end
     end
   end
@@ -531,6 +549,7 @@ describe FileController do
       obj.otherRightsURI = otherRights_local.pid
       obj.add_file(Base64.decode64(mov_content), '_1.mov', 'audio_source.mov')
       obj.add_file(Base64.decode64(mp4_content), '_2.mp4', 'audio_service.mp4')
+      obj.add_file(Base64.decode64(jpeg_content), '_4.jpg', 'image_icon.jpg')
       obj.save
       solr_index obj.pid
     end
@@ -551,6 +570,12 @@ describe FileController do
         get :show, id: obj.pid, ds: '_2.mp4'
         expect(response).to have_http_status(200)
       end
+
+      it 'can download the image icon' do
+        sign_in User.create!(provider: 'developer')
+        get :show, id: obj.pid, ds: '_4.jpg'
+        expect(response).to have_http_status(200)
+      end
     end
 
     describe 'public download' do
@@ -561,6 +586,11 @@ describe FileController do
 
       it 'cannot download the mp4 derivative' do
         get :show, id: obj.pid, ds: '_2.mp4'
+        expect(response).to have_http_status(403)
+      end
+
+      it 'cannot download the image icon' do
+        get :show, id: obj.pid, ds: '_4.jpg'
         expect(response).to have_http_status(403)
       end
     end
@@ -576,6 +606,12 @@ describe FileController do
         sign_in_anonymous '132.239.0.3'
         get :show, id: obj.pid, ds: '_2.mp4'
         expect(response).to have_http_status(403)
+      end
+
+      it 'can download the image icon' do
+        sign_in_anonymous '132.239.0.3'
+        get :show, id: obj.pid, ds: '_4.jpg'
+        expect(response).to have_http_status(200)
       end
     end
   end
@@ -650,6 +686,7 @@ describe FileController do
       obj.otherRightsURI = otherRights_metadata.pid
       obj.add_file(Base64.decode64(mov_content), '_1.mov', 'audio_source.mov')
       obj.add_file(Base64.decode64(mp4_content), '_2.mp4', 'audio_service.mp4')
+      obj.add_file(Base64.decode64(jpeg_content), '_4.jpg', 'image_icon.jpg')
       obj.save
       solr_index obj.pid
     end
@@ -670,6 +707,12 @@ describe FileController do
         get :show, id: obj.pid, ds: '_2.mp4'
         expect(response).to have_http_status(200)
       end
+
+      it 'can download the image icon' do
+        sign_in User.create!(provider: 'developer')
+        get :show, id: obj.pid, ds: '_4.jpg'
+        expect(response).to have_http_status(200)
+      end
     end
 
     describe 'public download' do
@@ -680,6 +723,11 @@ describe FileController do
 
       it 'cannot download the mp4 derivative' do
         get :show, id: obj.pid, ds: '_2.mp4'
+        expect(response).to have_http_status(403)
+      end
+
+      it 'cannot download the image icon' do
+        get :show, id: obj.pid, ds: '_4.jpg'
         expect(response).to have_http_status(403)
       end
     end
@@ -695,6 +743,12 @@ describe FileController do
         sign_in_anonymous '132.239.0.3'
         get :show, id: obj.pid, ds: '_2.mp4'
         expect(response).to have_http_status(403)
+      end
+
+      it 'can download the image icon' do
+        sign_in_anonymous '132.239.0.3'
+        get :show, id: obj.pid, ds: '_4.jpg'
+        expect(response).to have_http_status(200)
       end
     end
   end


### PR DESCRIPTION
Fixes #467

#### Local Checklist
- [x] Tests written and passing locally?
- [x] Code style checked?
- [ ] QA-ed locally?
- [x] Rebased with `master` branch?
- [ ] Configuration updated (if needed)?
- [ ] Documentation updated (if needed)?

#### What does this PR do?
Allow UCSD local users to download videos icons for UCSD IP/metadata-only collections, which is required for icon display in the search result page.

##### Why are we doing this? Any context of related work?
References #466, #483

@ucsdlib/developers - please review
