### PR TITLE
Use alpine for damspas

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -14,6 +14,7 @@ AllCops:
     - 'app/helpers/**/*'
     - 'app/controllers/catalog_controller.rb'
     - 'app/controllers/dams_resource_controller.rb'
+    - 'Gemfile'
 
 Rails:
     Enabled: true
@@ -33,7 +34,7 @@ Style/Documentation:
 Style/ConditionalAssignment:
   Exclude:
     - 'app/helpers/*'
-    
+
 Style/Next:
   Enabled: true
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,24 +1,33 @@
-FROM ruby:2.3.7
+FROM ruby:2.3.7-alpine
 
 # Maintainer
 MAINTAINER "Matt Critchlow <mcritchlow@ucsd.edu">
 
-RUN apt-get update -yqq \
- && apt-get install -yqq --no-install-recommends nodejs libicu-dev libfontconfig1-dev libjpeg-dev libfreetype6 \
- && apt-get clean
+RUN apk add --no-cache \
+  build-base \
+  busybox \
+  ca-certificates \
+  curl \
+  git \
+  gnupg1 \
+  gpgme \
+  less \
+  libffi-dev \
+  libxml2-dev \
+  libxslt-dev \
+  linux-headers \
+  libsodium-dev \
+  nodejs \
+  openssh-client \
+  postgresql-dev \
+  tzdata \
+  rsync \
+  wget
 
-ENV PHANTOM_JS_TAG 2.1.1
-
-# Downloading bin, unzipping & removing zip
-WORKDIR /tmp
-RUN wget -q http://cnpmjs.org/mirrors/phantomjs/phantomjs-${PHANTOM_JS_TAG}-linux-x86_64.tar.bz2 -O phantomjs.tar.bz2 \
-  && tar xjf phantomjs.tar.bz2 \
-  && rm -rf phantomjs.tar.bz2 \
-  && mv phantomjs-* phantomjs \
-  && mv /tmp/phantomjs/bin/phantomjs /usr/local/bin/phantomjs
-
-RUN echo "phantomjs binary is located at `which phantomjs`" \
-  && echo "just run 'phantomjs' (version `phantomjs -v`)"
+# Install phantomjs
+RUN wget -qO- "https://github.com/dustinblackman/phantomized/releases/download/2.1.1a/dockerized-phantomjs.tar.gz" | tar xz -C / \
+  && npm config set user 0 \
+  && npm install -g phantomjs-prebuilt
 
 # Trick to copy in Gemfile before other files.
 # This way bundle install step only runs again if THOSE files change

--- a/Gemfile
+++ b/Gemfile
@@ -7,11 +7,11 @@ gem 'active-fedora', '~> 6.7.8' # locked
 gem 'solrizer', '~> 3.1.0' # locked
 gem 'blacklight_advanced_search', '~> 2.2.0' # locked
 gem 'kaminari', '~> 0.15.1' # locked (0.16.0+ breaks pagination)
-gem 'share_notify', github: 'samvera-labs/share_notify', branch: 'master'
+gem 'share_notify', git: 'https://github.com/samvera-labs/share_notify', branch: 'master'
 
 # private fork of solrizer-fedora with auto-commit disabled
 #gem 'solrizer-fedora', '3.0.0.pre1' # PRE-LOCK
-gem "solrizer-fedora", github: 'ucsdlib/solrizer-fedora', ref: '87c2d35e'
+gem "solrizer-fedora", git: 'https://github.com/ucsdlib/solrizer-fedora', ref: '87c2d35e'
 
 gem 'sitemap_generator', '~> 5.3.1'
 
@@ -35,15 +35,12 @@ gem 'capistrano-rails', '~> 1.2.3'
 gem 'capistrano-rbenv', '~> 2.1.1'
 gem 'capistrano-bundler', '~> 1.2.0'
 
-gem "unicode", '0.4.4.3', :platforms => [:mri_18, :mri_19]
 gem "i18n", '~> 0.8.1'
 gem "bootstrap-sass", '~> 2.3.2.2' # locked because blacklight 4.7
 gem "bower-rails", "~> 0.11.0"
 gem "responders", "~> 2.4.0"
 gem 'nokogiri', '1.8.2'
 
-# See https://github.com/sstephenson/execjs#readme for more supported runtimes
-gem 'therubyracer', '~> 0.12.3', :platforms => :ruby
 gem 'uglifier', '~> 3.2.0'
 gem 'rspec-mocks', '3.6.0'
 gem 'newrelic_rpm', '4.1.0.333'
@@ -72,6 +69,5 @@ group :development, :test do
 end
 
 group :staging do
-  gem 'activerecord-postgresql-adapter'
   gem 'rake', '~> 12.0.0'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,5 +1,5 @@
 GIT
-  remote: git://github.com/samvera-labs/share_notify.git
+  remote: https://github.com/samvera-labs/share_notify
   revision: 96c16ab13c596f479f83cb55c70b27309f4d5f2d
   branch: master
   specs:
@@ -8,7 +8,7 @@ GIT
       httparty
 
 GIT
-  remote: git://github.com/ucsdlib/solrizer-fedora.git
+  remote: https://github.com/ucsdlib/solrizer-fedora
   revision: 87c2d35e89df19bb4535e1f713a68b0dc469498a
   ref: 87c2d35e
   specs:
@@ -161,7 +161,7 @@ GEM
       uber (~> 0.0.4)
     http-cookie (1.0.2)
       domain_name (~> 0.5)
-    httparty (0.16.1)
+    httparty (0.16.2)
       multi_xml (>= 0.5.2)
     hydra-access-controls (6.5.2)
       active-fedora (~> 6.7)
@@ -199,7 +199,6 @@ GEM
     kgio (2.11.0)
     launchy (2.4.3)
       addressable (~> 2.3)
-    libv8 (3.16.14.19)
     logger (1.2.8)
     lograge (0.5.1)
       actionpack (>= 4, < 5.2)
@@ -309,7 +308,6 @@ GEM
       rdf-xsd (>= 1.0)
     rdf-xsd (1.1.2)
       rdf (~> 1.1)
-    ref (2.0.0)
     responders (2.4.0)
       actionpack (>= 4.2.0, < 5.3)
       railties (>= 4.2.0, < 5.3)
@@ -406,9 +404,6 @@ GEM
     stomp (1.3.4)
     term-ansicolor (1.6.0)
       tins (~> 1.0)
-    therubyracer (0.12.3)
-      libv8 (~> 3.16.14.15)
-      ref
     thor (0.19.4)
     thread_safe (0.3.6)
     tilt (1.4.1)
@@ -421,7 +416,6 @@ GEM
     unf (0.1.4)
       unf_ext
     unf_ext (0.0.7.1)
-    unicode (0.4.4.3)
     unicode-display_width (1.2.1)
     unicorn (5.3.0)
       kgio (~> 2.6)
@@ -491,10 +485,8 @@ DEPENDENCIES
   solrizer (~> 3.1.0)
   solrizer-fedora!
   sprockets (~> 2.12.4)
-  therubyracer (~> 0.12.3)
   uglifier (~> 3.2.0)
-  unicode (= 0.4.4.3)
   unicorn (~> 5.3.0)
 
 BUNDLED WITH
-   1.16.1
+   1.16.3

--- a/docker/README.md
+++ b/docker/README.md
@@ -12,15 +12,40 @@ You have two choices for running damspas with Docker:
 
 Setup rails databases:
 - Self contained:
-    - `docker-compose -f docker/dev/docker-compose.yml exec web bundle exec rake db:setup`
+    - `docker-compose -f docker/dev/docker-compose.yml exec -e RAILS_ENV=test web bundle exec rake db:create db:migrate`
 - Dependencies only:
-    - `bundle exec rake db:setup`
+    - `RAILS_ENV=test bundle exec rake db:create db:migrate`
 
 Run damspas test suite:
 - Self contained:
     - `docker-compose -f docker/dev/docker-compose.yml exec web bundle exec rake spec`
 - Dependencies only:
     - `bundle exec rake spec`
+
+# Development Workflow
+If you make changes to the damspas codebase that you want to test, you will need to rebuild the `web`
+container which hosts the damspas application. This can be done as follows:
+
+- Kill/stop the running docker-compose session
+- Rebuild web container: `docker-compose -f docker/dev/docker-compose.yml build`
+- Start docker-compose session again: `docker-compose -f docker/dev/docker-compose.yml up`
+- This should only rebuild what is necessary. And won't run `bundle install`
+  unless you change the Gemfile
+
+## Errors w/ the web container
+
+If you get an error like:
+```
+web_1 | A server is already running. Check /usr/src/app/tmp/pids/server.pid.
+```
+
+You probably didn't cleanly shut down the web container, leaving `tmp` files in
+the container and your local repo that prevent a clean start again. In this case, you should remove any files in `tmp/pids` on your local machine/host.
+
+Now recreate the container so it removes the internal temp files:
+```
+docker-compose -f docker/dev/docker-compose.yml up --force-recreate
+```
 
 # Teardown
 To remove all containers:

--- a/docker/dev/docker-compose.yml
+++ b/docker/dev/docker-compose.yml
@@ -17,6 +17,8 @@ services:
 
   database:
     image: ucsdlib/docker-postgres-damsrepo
+    ports:
+      - "5432:5432"
     # volumes:
     #   - db-data:/var/lib/postgresql/data
     env_file:
@@ -37,6 +39,8 @@ services:
 
   tomcat:
     image: ucsdlib/docker-tomcat-damsrepo
+    ports:
+      - "8080:8080"
     command: ["dockerize", "-wait", "tcp://solr:8983", "-timeout", "1m", "-wait", "tcp://database:5432", "-timeout", "1m", "catalina.sh", "run"]
     depends_on:
       - database

--- a/spec/features/ruby_version_spec.rb
+++ b/spec/features/ruby_version_spec.rb
@@ -2,7 +2,7 @@ require 'spec_helper'
 
 feature "ruby version" do
   scenario "objects should have meta tags" do
-    pending("Waiting on circleci image to support current ruby")
+    skip("Waiting on circleci image to support current ruby")
     ver = File.read(File.join(File.dirname(__FILE__), '..', '..', '.ruby-version')).chomp
     visit ruby_version_path
     expect(page).to have_text "ruby version = #{ver}"


### PR DESCRIPTION
Fixes #501 

#### Local Checklist
- [x] Tests written and passing locally?
- [x] QA-ed locally?
- [x] Rebased with `master` branch?
- [x] Configuration updated (if needed)?
- [x] Documentation updated (if needed)?

#### What does this PR do?
Note this doesn't actually 'fix' #501, but after some research yesterday I've come to realize that while I can setup chromium and chromedriver to replace phantomjs in our Docker setup, far too many tests would need to be rewritten because we'd need to bump Capybara to a modern version. I made some effort to see how much work this would be, and it's more than seems to be of any value to us all, in my opinion.

So instead I've focused on replacing the Debian-based image for local development with an Alpine based one. This cuts the overall image size for damspas from 2.2G to 650M. Which is significant.. I might be able to get it even smaller with a multi-stage build, but I think this is good for now.

The two other commits are housecleaning and preparation to make the Alpine shift possible.

##### Why are we doing this? Any context of related work?
We are doing this to try and cut down on the footprint of using Docker for our local dev environment. This brings all of our images to using Alpine linux, which is the smallest starting point we can go with for now.

#### Where should a reviewer start?
- See `docker/README.md` changes, feedback welcome
- Please run the `docker/dev/docker-compose.yml` setup locally if you can, since we can't use it in circleci.
- Note that the ruby version test was changed to `skip` since it actually passes in the dev/non-circleci context and would then trigger an error. 

#### Manual testing steps?
- Please run the `docker/dev/docker-compose.yml` setup locally if you can, since we can't use it in circleci.

@ucsdlib/developers - please review
