### PR TITLE
Fix display behavior of metadata-only collections

### DIFF
--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -321,8 +321,7 @@ class CatalogController < ApplicationController
 
   def metadata_only_collections(params)
     meta_colls = []
-    solr_params = {}
-    solr_params[:fq] = ["{!join from=collections_tesim to=id}#{metadata_only_fquery}"]
+    solr_params = { q: "{!join from=collections_tesim to=id}#{metadata_only_fquery}", fq: 'type_tesim:Collection', rows: 300 }
     response = raw_solr(solr_params.merge(params))
     response.docs.each do |doc|
       mix_obj = mix_objects?(doc['id_t'], metadata_obj_count(doc['id_t']))

--- a/app/helpers/catalog_helper.rb
+++ b/app/helpers/catalog_helper.rb
@@ -96,14 +96,14 @@ module CatalogHelper
     dateVal
   end
 
-  def display_access_control_level(document, metadata_colls)
+  def display_access_control_level(document, metadata_colls, mix_obj, meta_only_obj)
     access_group = document['read_access_group_ssim'] # "public" > "local" > "dams-curator" == "dams-rci" == default
     view_access = 'Curator Only'
     if access_group
-      if metadata_colls.include?("#{document['id']}true")
-        view_access = 'Some items restricted'
-      elsif metadata_colls.include?(document['id']) || metadata_display?(rights_data(document))
-        view_access = 'Restricted View'
+      if metadata_colls.include?("#{document['id']}true") || mix_obj
+        view_access = hide_label?(document) ? nil : 'Some items restricted'
+      elsif metadata_colls.include?(document['id']) || meta_only_obj
+        view_access = hide_label?(document) ? nil : 'Restricted View'
       elsif access_group.include?('public')
         view_access = nil
       elsif access_group.include?('local')
@@ -147,7 +147,7 @@ module CatalogHelper
   def object_thumbnail_url(document)
     restricted_view = metadata_display?(rights_data(document))
     return nil unless restricted_view || (has_thumbnail?(document) && thumbnail_url(document, nil))
-    if restricted_view
+    if restricted_view && cannot?(:read, document)
       url = 'https://library.ucsd.edu/assets/dams/site/thumb-restricted.png'
       image_tag(url, alt: '', class: 'dams-search-thumbnail')
     else

--- a/app/views/catalog/_display_access_control_level.html.erb
+++ b/app/views/catalog/_display_access_control_level.html.erb
@@ -1,4 +1,4 @@
-<% acl = display_access_control_level(document, metadata_colls) %>
+<% acl = display_access_control_level(document, metadata_colls, false, metadata_display?(rights_data(document))) %>
 <% if acl != nil %>
   <li><span class="dams-search-results-fields-label">Access:</span> <span><%= acl %></span></li>
 <% end %>

--- a/app/views/dams_objects/_data_viewer.html.erb
+++ b/app/views/dams_objects/_data_viewer.html.erb
@@ -13,10 +13,12 @@
 	%>
 
 	<div class="form-actions dams-download-button">
-	  <a id="data-view-file" class="btn <%=btnColor%> pull-right" href="<%= viewFilePath %>"><i class="glyphicon glyphicon-eye-open icon-white"></i> View file</a>
-	  <a id="data-download-file" class="btn btn-link pull-left btn-mini hidden-phone" href="<%= filePath %>" rel="nofollow"><i class="glyphicon glyphicon-download-alt"></i> Download file</a>
-	  <a id="data-download-file-phone" class="btn pull-left btn-mini visible-phone" href="<%= filePath %>" rel="nofollow"><i class="glyphicon glyphicon-download-alt"></i> Download file</a>
-	  <% if can? :update, @document%>
+    <% if can?(:edit, @document) || can?(:read, @document) && can_download?(@document)%>
+	    <a id="data-view-file" class="btn <%=btnColor%> pull-right" href="<%= viewFilePath %>"><i class="glyphicon glyphicon-eye-open icon-white"></i> View file</a>
+	    <a id="data-download-file" class="btn btn-link pull-left btn-mini hidden-phone" href="<%= filePath %>" rel="nofollow"><i class="glyphicon glyphicon-download-alt"></i> Download file</a>
+	    <a id="data-download-file-phone" class="btn pull-left btn-mini visible-phone" href="<%= filePath %>" rel="nofollow"><i class="glyphicon glyphicon-download-alt"></i> Download file</a>
+    <% end %>
+    <% if can? :update, @document%>
 	    <% if (defined?(sourcefilePath) && !sourcefilePath.nil? && sourcefilePath != filePath)%>
 	      <a class="btn btn-link pull-left btn-mini hidden-phone" href="<%= sourcefilePath %>" rel="nofollow"><i class="glyphicon glyphicon-download-alt"></i> Download <%= File.extname(sourcefilePath.gsub('/download','')).upcase.gsub('.','')%> source</a>
 	      <a class="btn pull-left btn-mini visible-phone" href="<%= sourcefilePath %>" rel="nofollow"><i class="glyphicon glyphicon-download-alt"></i> Download <%= File.extname(sourcefilePath.gsub('/download','')).upcase.gsub('.','')%> source</a>

--- a/app/views/shared/fields/_access_control_level.html.erb
+++ b/app/views/shared/fields/_access_control_level.html.erb
@@ -1,29 +1,13 @@
 <%
 	htmlOpen = "<dt>%s</dt><dd><ul>"
 	htmlClose = '</ul></dd>'
-	accessGroup = @document['read_access_group_ssim'] # "public" > "local" > "dams-curator" == "dams-rci" == default
-	viewAccess = nil
 
-	if accessGroup != nil
+    viewAccess = display_access_control_level(@document, [], @mix_objects, @metadata_only)
 
-                if @mix_objects
-                    viewAccess = 'Some items restricted'
-                elsif @metadata_only
-                    viewAccess = 'Restricted View'
-		elsif accessGroup.include?('public')
-		    viewAccess = :public	  
-	        elsif accessGroup.include?('local')
-		    viewAccess = 'Restricted to UC San Diego use only'
-		else
-		    viewAccess = 'Curator Only'
-		end
-
-		if viewAccess != :public
-			htmlOpen %= 'Access'
-			concat htmlOpen.html_safe
-			concat "<li>#{viewAccess}</li>".html_safe
-			concat htmlClose.html_safe
-		end
-
-	end
+    if viewAccess
+        htmlOpen %= 'Access'
+        concat htmlOpen.html_safe
+        concat "<li>#{viewAccess}</li>".html_safe
+        concat htmlClose.html_safe
+    end
 %>

--- a/lib/dams/controller_helper.rb
+++ b/lib/dams/controller_helper.rb
@@ -905,7 +905,7 @@ module Dams
     def local_collection?(document)
       data = (Array(document['collection_json_tesim']) + Array(document['visibility_tesim'])).flatten.compact
       return false if data.blank?
-      data.any? { |t| t.include?('local')}
+      data.any? { |t| t.include?('local') }
     end
 
     def local_display?(data)

--- a/lib/dams/controller_helper.rb
+++ b/lib/dams/controller_helper.rb
@@ -898,6 +898,21 @@ module Dams
       end
     end
 
+    def hide_label?(document)
+      cannot?(:edit, document) && can?(:read, document) && (local_display?(rights_data(document)) || local_collection?(document))
+    end
+
+    def local_collection?(document)
+      data = (Array(document['collection_json_tesim']) + Array(document['visibility_tesim'])).flatten.compact
+      return false if data.blank?
+      data.any? { |t| t.include?('local')}
+    end
+
+    def local_display?(data)
+      return false if data.blank?
+      data.any? { |t| t.include?('localDisplay') }
+    end
+
     def metadata_display?(data)
       return false if data.blank?
       data.any? { |t| t.include?('localDisplay') || t.include?('metadataDisplay') }

--- a/spec/features/catalog_spec.rb
+++ b/spec/features/catalog_spec.rb
@@ -613,7 +613,7 @@ feature 'Visitor wants to view object for public metadata-only collection in the
     expect(page).to have_content('Restricted View')
   end
 
-  scenario 'local user should not see the grey generic thumbnail and still see restricted access info' do
+  scenario 'local user should not see the grey generic thumbnail and restricted access label' do
     sign_in_anonymous '132.239.0.3'
     visit catalog_index_path({:q => 'xx909090zz'})
     expect(page).to_not have_css('img.dams-search-thumbnail[src="https://library.ucsd.edu/assets/dams/site/thumb-restricted.png"]')

--- a/spec/features/dams_collections_spec.rb
+++ b/spec/features/dams_collections_spec.rb
@@ -387,12 +387,12 @@ feature "Visitor wants to view a UCSD IP only collection's page with metadata-on
     @obj.delete
   end
 
-  scenario 'should see Restricted View access control information' do
+  scenario 'local user should not see Restricted View access label' do
     sign_in_anonymous '132.239.0.3'
     visit dams_collection_path @metadataOnlyCollection.pid
-    expect(page).to have_content('Restricted View')
+    expect(page).to_not have_content('Restricted View')
     visit dams_collection_path @localOnlyCollection.pid
-    expect(page).to have_content('Restricted View')
+    expect(page).to_not have_content('Restricted View')
   end
 
   scenario 'should not see Restricted View access control information' do
@@ -401,10 +401,10 @@ feature "Visitor wants to view a UCSD IP only collection's page with metadata-on
     expect(page).to_not have_content('Restricted View')
   end
   
-  scenario 'should see Restricted View access control information when visit browse by collection page' do
+  scenario 'local user should not see Restricted View access label when visit browse by collection page' do
     sign_in_anonymous '132.239.0.3'
     visit '/collections'
-    expect(page).to have_content('Restricted View')
+    expect(page).to_not have_content('Restricted View')
   end
 end
 
@@ -445,7 +445,7 @@ feature "Visitor wants to view a public collection's page with metadata-only obj
     expect(page).to have_content('Restricted View')
   end
   
-  scenario 'local user should see Restricted View access control information when visit browse by collection page' do
+  scenario 'local user should see Restricted View access label when visit browse by collection page' do
     sign_in_anonymous '132.239.0.3'
     visit '/collections'
     expect(page).to have_content('Restricted View')
@@ -501,10 +501,27 @@ feature "Visitor wants to view a public collection's page with mixed objects" do
 
   scenario 'public user should see some items restricted access information when search for collection' do
     visit catalog_index_path( {:q => @publicCollection.pid} )
-    puts "collection id #{@publicCollection.pid}"
     expect(page).to_not have_content('Restricted View')
     expect(page).to have_content('Some items restricted')
-  end  
+  end
+  
+  scenario 'local user should see access label when visit browse by collection page or search for collection' do
+    sign_in_anonymous '132.239.0.3'
+    visit '/collections'
+    expect(page).to have_content('Some items restricted')
+
+    visit catalog_index_path( {:q => @publicCollection.pid} )
+    expect(page).to have_content('Some items restricted')
+  end
+  
+  scenario 'curator user should see access label when visit browse by collection page or search for collection' do
+    sign_in_developer
+    visit '/collections'
+    expect(page).to have_content('Some items restricted')
+
+    visit catalog_index_path( {:q => @publicCollection.pid} )
+    expect(page).to have_content('Some items restricted')
+  end
 end
 
 feature "Visitor wants to view a local collection's page with mixed objects" do
@@ -547,6 +564,26 @@ feature "Visitor wants to view a local collection's page with mixed objects" do
   scenario 'public user should see some items restricted access information when search for collection' do
     visit catalog_index_path( {:q => @localCollection.pid} )
     expect(page).to_not have_content('Restricted View')
+    expect(page).to have_content('Some items restricted')
+  end
+  
+  scenario 'local user should not see access label when visit browse by collection page or search for collection' do
+    sign_in_anonymous '132.239.0.3'
+    visit '/collections'
+    expect(page).to_not have_content('Restricted View')
+    expect(page).to_not have_content('Some items restricted')
+
+    visit catalog_index_path( {:q => @localCollection.pid} )
+    expect(page).to_not have_content('Restricted View')
+    expect(page).to_not have_content('Some items restricted')
+  end
+  
+  scenario 'curator user should see access label when visit browse by collection page or search for collection' do
+    sign_in_developer
+    visit '/collections'
+    expect(page).to have_content('Some items restricted')
+
+    visit catalog_index_path( {:q => @localCollection.pid} )
     expect(page).to have_content('Some items restricted')
   end  
 end
@@ -593,4 +630,22 @@ feature "Visitor wants to view a metadata-only public collection's page with no 
     expect(page).to have_content('Restricted View')
     expect(page).to_not have_content('Some items restricted')
   end
+  
+  scenario 'local user should see access label when visit browse by collection page or search for collection' do
+    sign_in_anonymous '132.239.0.3'
+    visit '/collections'
+    expect(page).to have_content('Restricted View')
+
+    visit catalog_index_path( {:q => @publicCollection.pid} )
+    expect(page).to have_content('Restricted View')
+  end
+  
+  scenario 'curator user should see access label when visit browse by collection page or search for collection' do
+    sign_in_developer
+    visit '/collections'
+    expect(page).to have_content('Restricted View')
+
+    visit catalog_index_path( {:q => @publicCollection.pid} )
+    expect(page).to have_content('Restricted View')
+  end 
 end


### PR DESCRIPTION
Fixes #466 

#### Local Checklist
- [x] Tests written and passing locally?
- [x] Code style checked?
- [x] QA-ed locally?
- [x] Rebased with `master` branch?
- [ ] Configuration updated (if needed)?
- [ ] Documentation updated (if needed)?

#### What does this PR do?
Fix restricted thumbnail issue for search results page.
Fix pdf file download issue for Scientific Voyages and Expedition Reports collection.
Add hide access label function for local user in search/browse by collection page, single object and collection view for metadata-only collection.

References #466 

#### Deployment Instructions
It has been deployed to staging and tested by Gabriela, Longshou and me.

@ucsdlib/developers - please review

