### PR TITLE
Fix embargo banner view issue

### DIFF
--- a/app/views/dams_objects/_complex_object_viewer.html.erb
+++ b/app/views/dams_objects/_complex_object_viewer.html.erb
@@ -7,13 +7,15 @@
 %>
 
 <%# CHECK FOR RESTRICTED NOTICE %>
-<% restrictedNotice = grabRestrictedText(@document['otherNote_json_tesim']) %>
-<% unless restrictedNotice.nil? %>
-  <div class="restricted-notice">
-    <div>
-      <%= restrictedNotice %>
+<% if cannot?(:read, @document) || cultural_sensitive?(@document) then %>
+  <% restrictedNotice = grabRestrictedText(@document['otherNote_json_tesim']) %>
+  <% unless restrictedNotice.nil? %>
+    <div class="restricted-notice">
+      <div>
+        <%= restrictedNotice %>
+      </div>
     </div>
-  </div>
+  <% end %>
 <% end %>
 <% access_notice = grab_access_text(@document) if cannot?(:read, @document) %>
 

--- a/app/views/dams_objects/_simple_object_viewer.html.erb
+++ b/app/views/dams_objects/_simple_object_viewer.html.erb
@@ -1,5 +1,6 @@
 <% if defined?(fileType) %>
 
+<% if cannot?(:read, @document) || cultural_sensitive?(@document) then %>
   <% restrictedNotice = grabRestrictedText(@document['otherNote_json_tesim']) %>
   <% unless restrictedNotice.nil? %>
     <div class="restricted-notice">
@@ -8,6 +9,7 @@
 	    </div>
     </div>
   <% end %>
+<% end %>
 
 <% if cannot?(:read, @document) then %>
 

--- a/app/views/dams_objects/metadata.html.erb
+++ b/app/views/dams_objects/metadata.html.erb
@@ -20,6 +20,7 @@
 
 
 <%# BEGIN RESTRICTED NOTICE %>
+    <% if cannot?(:read, @document) || cultural_sensitive?(@document) then %>
         <% restrictedNotice = grabRestrictedText(@document['otherNote_json_tesim']) %>
         <% unless restrictedNotice.nil? %>
           <div class="restricted-notice">
@@ -29,6 +30,7 @@
           </div>
           <div class="simple-object"></div>
         <% end %>
+    <% end %>
 <%# END RESTRICTED NOTICE %>
     <% if cannot?(:read, @document) then %>
         <% accessNotice = grab_access_text(@document) %>

--- a/lib/dams/controller_helper.rb
+++ b/lib/dams/controller_helper.rb
@@ -918,6 +918,12 @@ module Dams
       data.any? { |t| t.include?('localDisplay') || t.include?('metadataDisplay') }
     end
 
+    def cultural_sensitive?(document)
+      data = Array(document['otherNote_json_tesim']).flatten.compact
+      return false if data.blank?
+      data.any? { |t| t.include?('Culturally sensitive content:') }
+    end
+
     def total_count(collection_id)
       solr_params = build_params("collections_tesim:#{collection_id}")
       raw_solr(solr_params).response['numFound'].to_i

--- a/spec/fixtures/embargoedObject.rdf.xml
+++ b/spec/fixtures/embargoedObject.rdf.xml
@@ -162,18 +162,6 @@
         <dams:preservationLevel>full</dams:preservationLevel>
       </dams:File>
     </dams:hasFile>
-    <dams:otherRights>
-		 <dams:OtherRights>
-		
-		    <dams:permission>
-		      <dams:Permission>
-		        <dams:type>metadataDisplay</dams:type>
-		      </dams:Permission>
-		    </dams:permission>
-		    <dams:otherRightsNote>Please contact Mandeville Special Collections &amp; Archives at spcoll@ucsd.edu or (858) 534-2533 for more information about this object.</dams:otherRightsNote>
-		    <dams:otherRightsBasis>fair use</dams:otherRightsBasis>
-		  </dams:OtherRights> 
-    </dams:otherRights>
     <dams:typeOfResource>still image</dams:typeOfResource>
     <dams:hasFile>
       <dams:File rdf:about="http://library.ucsd.edu/ark:/20775/zz2765588d/5.jpg">


### PR DESCRIPTION
Fixes #513 

#### Local Checklist
- [x] Tests written and passing locally?
- [x] Code style checked?
- [x] QA-ed locally?
- [x] Rebased with `master` branch?
- [ ] Configuration updated (if needed)?
- [ ] Documentation updated (if needed)?

#### What does this PR do?

Fix behavior of embargoed/culturally sensitive objects.
Curator should not see the 'embargo banner', and should be able to view the images.

##### Why are we doing this? Any context of related work?
References #513 

#### Manual testing steps?

http://libraryqa.ucsd.edu/dc/object/bb4301347c

#### Screenshots

![embargo](https://user-images.githubusercontent.com/1864660/43793318-04ce0c9e-9a30-11e8-8b6b-9bb89b3b5936.png)

#### Deployment Instructions

It has been deployed to qa and staging to test.

@ucsdlib/developers - please review
