### PR TITLE
Show generic thumbnail for click-thru object

### DIFF
--- a/app/helpers/catalog_helper.rb
+++ b/app/helpers/catalog_helper.rb
@@ -146,8 +146,8 @@ module CatalogHelper
 
   def object_thumbnail_url(document)
     restricted_view = metadata_display?(rights_data(document))
-    return nil unless restricted_view || (has_thumbnail?(document) && thumbnail_url(document, nil))
-    if restricted_view && cannot?(:read, document)
+    return nil unless restricted_view || (has_thumbnail?(document) && thumbnail_url(document, nil)) || cultural_sensitive?(document)
+    if (restricted_view && cannot?(:read, document)) || (cultural_sensitive?(document) && cannot?(:edit, document)) 
       url = 'https://library.ucsd.edu/assets/dams/site/thumb-restricted.png'
       image_tag(url, alt: '', class: 'dams-search-thumbnail')
     else


### PR DESCRIPTION
Fixes #516 

#### Local Checklist
- [x] Tests written and passing locally?
- [x] Code style checked?
- [x] QA-ed locally?
- [x] Rebased with `master` branch?
- [ ] Configuration updated (if needed)?
- [ ] Documentation updated (if needed)?

#### What does this PR do?

Show generic thumbnail in grid for click-thru agreement objects for public and local user.

#### Screenshots
![objclickthru](https://user-images.githubusercontent.com/1864660/44430118-9b84bd80-a54e-11e8-987c-edf4b6bc685d.png)


@ucsdlib/developers - please review
