### PR TITLE
Update access label for mixed objects collection and use 'Restricted to UC San Diego use only' under certain conditions

### DIFF
--- a/app/helpers/catalog_helper.rb
+++ b/app/helpers/catalog_helper.rb
@@ -100,14 +100,14 @@ module CatalogHelper
     access_group = document['read_access_group_ssim'] # "public" > "local" > "dams-curator" == "dams-rci" == default
     view_access = 'Curator Only'
     if access_group
-      if metadata_colls.include?("#{document['id']}true") || mix_obj
+      if access_group.include?('local') && !mix_obj && !metadata_colls.include?("#{document['id']}true")
+        view_access = 'Restricted to UC San Diego use only'
+      elsif metadata_colls.include?("#{document['id']}true") || mix_obj
         view_access = hide_label?(document) ? nil : 'Some items restricted'
       elsif metadata_colls.include?(document['id']) || meta_only_obj
         view_access = hide_label?(document) ? nil : 'Restricted View'
       elsif access_group.include?('public')
         view_access = nil
-      elsif access_group.include?('local')
-        view_access = 'Restricted to UC San Diego use only'
       end
 
     end

--- a/spec/features/catalog_spec.rb
+++ b/spec/features/catalog_spec.rb
@@ -522,14 +522,14 @@ feature 'Visitor wants to view object of metadata data-only visibility collectio
   scenario 'public user should see the grey generic thumbnail and restricted access info' do
     visit catalog_index_path({:q => 'xx909090zz'})
     expect(page).to have_css('img.dams-search-thumbnail[src="https://library.ucsd.edu/assets/dams/site/thumb-restricted.png"]')
-    expect(page).to have_content('Restricted View')
+    expect(page).to have_content('Restricted to UC San Diego use only')
   end
 
   scenario 'curator user should not see the grey generic thumbnail and still see restricted access info' do
     sign_in_developer
     visit catalog_index_path({:q => 'xx909090zz'})
     expect(page).to_not have_css('img.dams-search-thumbnail[src="https://library.ucsd.edu/assets/dams/site/thumb-restricted.png"]')
-    expect(page).to have_content('Restricted View')
+    expect(page).to have_content('Restricted to UC San Diego use only')
   end
   
   scenario 'local user should not see the grey generic thumbnail and restricted access info' do
@@ -562,7 +562,7 @@ feature 'Visitor wants to view localDisplay License object in UCSD local collect
     sign_in_developer
     visit catalog_index_path({:q => @localObj.pid})
     expect(page).to_not have_css('img.dams-search-thumbnail[src="https://library.ucsd.edu/assets/dams/site/thumb-restricted.png"]')
-    expect(page).to have_content('Restricted View')
+    expect(page).to have_content('Restricted to UC San Diego use only')
   end
 
   scenario 'local user should not see the grey generic thumbnail and restricted access info' do
@@ -575,7 +575,7 @@ feature 'Visitor wants to view localDisplay License object in UCSD local collect
   scenario 'public user should see the grey generic thumbnail and restricted access info' do
     visit catalog_index_path({:q => @localObj.pid})
     expect(page).to have_css('img.dams-search-thumbnail[src="https://library.ucsd.edu/assets/dams/site/thumb-restricted.png"]')
-    expect(page).to have_content('Restricted View')
+    expect(page).to have_content('Restricted to UC San Diego use only')
   end
 end
 
@@ -585,46 +585,6 @@ feature 'Visitor wants to view contact form' do
     visit contact_path
     expect(page).to have_content('Contact Us')
     expect(page).to have_selector('#mf_placeholder')
-  end
-end
-
-feature 'Visitor wants to view object for public metadata-only collection in the search result page' do
-  before(:all) do
-    ns = Rails.configuration.id_namespace
-    @note = DamsNote.create type: "local attribution", value: "Digital Library Development Program, UC San Diego, La Jolla, 92093-0175"
-    @localDisplay = DamsOtherRight.create permissionType: "localDisplay"
-    @publicCollection = DamsProvenanceCollection.create titleValue: "Test Public Collection", visibility: "public"    
-    @localObj = DamsObject.create pid: 'xx909090zz', titleValue: 'Test Object with localDisplay', provenanceCollectionURI: @publicCollection.pid, otherRightsURI: @localDisplay.pid, note_attributes: [{ id: RDF::URI.new("#{ns}#{@note.pid}") }], copyright_attributes: [{status: 'Under Copyright'}]
-    solr_index @note.pid
-    solr_index @localDisplay.pid
-    solr_index @publicCollection.pid
-    solr_index @localObj.pid
-  end
-  after(:all) do
-    @note.delete
-    @localDisplay.delete
-    @publicCollection.delete
-    @localObj.delete
-  end
-
-  scenario 'public user should see the grey generic thumbnail and restricted access info' do
-    visit catalog_index_path({:q => 'xx909090zz'})
-    expect(page).to have_css('img.dams-search-thumbnail[src="https://library.ucsd.edu/assets/dams/site/thumb-restricted.png"]')
-    expect(page).to have_content('Restricted View')
-  end
-
-  scenario 'local user should not see the grey generic thumbnail and restricted access label' do
-    sign_in_anonymous '132.239.0.3'
-    visit catalog_index_path({:q => 'xx909090zz'})
-    expect(page).to_not have_css('img.dams-search-thumbnail[src="https://library.ucsd.edu/assets/dams/site/thumb-restricted.png"]')
-    expect(page).to_not have_content('Restricted View')
-  end
-  
-  scenario 'curator user should not see the grey generic thumbnail and still see restricted access info' do
-    sign_in_developer
-    visit catalog_index_path({:q => 'xx909090zz'})
-    expect(page).to_not have_css('img.dams-search-thumbnail[src="https://library.ucsd.edu/assets/dams/site/thumb-restricted.png"]')
-    expect(page).to have_content('Restricted View')
   end
 end
 

--- a/spec/features/dams_object_spec.rb
+++ b/spec/features/dams_object_spec.rb
@@ -726,20 +726,20 @@ describe "Curator User wants to view a metadata-only complex object" do
     @metadataOnlyObj.delete
   end
 
-  scenario 'should see Restricted View access control information but not banner access text' do
+  scenario 'should see Restricted access control information but not banner access text' do
     visit dams_object_path @metadataOnlyObj.pid
     expect(page).to have_selector('#component-pager-label', :text=>'Component 1 of 4')
     expect(page).to have_content('Interval 1 (dredge, rock)')
-    expect(page).to have_selector('div.file-metadata', text: 'Access Restricted View')
+    expect(page).to have_selector('div.file-metadata', text: 'Restricted to UC San Diego use only')
     expect(page).to_not have_selector('div.restricted-notice-complex', text: restricted_note)
   end
 
-  scenario 'should see Restricted View access control info in other component' do 
+  scenario 'should see Restricted access control info in other component' do 
     visit dams_object_path @metadataOnlyObj.pid
     click_button 'component-pager-forward'
     find('#component-pager-label').should have_content('Component 2 of 4')
     expect(page).to have_content('Files')
-    expect(page).to have_selector('div.file-metadata', text: 'Access Restricted View')
+    expect(page).to have_selector('div.file-metadata', text: 'Access Restricted to UC San Diego use only')
   end
 end
 
@@ -960,13 +960,13 @@ describe "User wants to view simple object for local metadata-only collection" d
     @obj.delete
   end
 
-  scenario 'curator user should see Restricted View access control information and download link' do
+  scenario 'curator user should see Restricted access control information and download link' do
     sign_in_developer
     visit dams_object_path @metadataOnlyObj.pid
-    expect(page).to have_content('Restricted View')
+    expect(page).to have_content('Restricted to UC San Diego use only')
     expect(page).to have_link('', href:"/object/#{@metadataOnlyObj.id}/_1.mp4/download?access=curator")
     visit dams_object_path @localObj.pid
-    expect(page).to have_content('Restricted View')
+    expect(page).to have_content('Restricted to UC San Diego use only')
   end
 
   scenario 'curator user should not see Restricted View access control information' do
@@ -1564,20 +1564,17 @@ describe "User wants to view cultural sensitive object for public collection" do
   scenario 'curator user should not see the grey generic thumbnail' do
     sign_in_developer
     visit catalog_index_path({:q => @sensitiveObj.pid})
-    #puts page.body
     expect(page).to_not have_css('img.dams-search-thumbnail[src="https://library.ucsd.edu/assets/dams/site/thumb-restricted.png"]')
   end  
 
   scenario 'local user should see the grey generic thumbnail' do
     sign_in_anonymous '132.239.0.3'
     visit catalog_index_path({:q => @sensitiveObj.pid})
-    #puts page.body
     expect(page).to have_css('img.dams-search-thumbnail[src="https://library.ucsd.edu/assets/dams/site/thumb-restricted.png"]')
   end
   
   scenario 'public user should see the grey generic thumbnail' do
     visit catalog_index_path({:q => @sensitiveObj.pid})
-    #puts page.body
     expect(page).to have_css('img.dams-search-thumbnail[src="https://library.ucsd.edu/assets/dams/site/thumb-restricted.png"]')
   end 
 end


### PR DESCRIPTION
Fixes #519

#### Local Checklist
- [x] Tests written and passing locally?
- [x] Code style checked?
- [x] QA-ed locally?
- [x] Rebased with `master` branch?
- [ ] Configuration updated (if needed)?
- [ ] Documentation updated (if needed)?

#### What does this PR do?

Update access label for mixed objects collection and use 'Restricted to UC San Diego use only' under certain conditions

#### Screenshots

It has been deployed to staging.
![localcollection2](https://user-images.githubusercontent.com/1864660/44755699-0fd5d880-aadc-11e8-9c33-8cf9fdb6fa64.png)
![kelcocollection](https://user-images.githubusercontent.com/1864660/44755700-0fd5d880-aadc-11e8-88e6-18ef22085ac7.png)


@ucsdlib/developers - please review
