### PR TITLE
Fixed #521 - Include the collection link in UCSD IP/metadata-only object

### DIFF
--- a/app/views/shared/fields/_collection.html.erb
+++ b/app/views/shared/fields/_collection.html.erb
@@ -44,8 +44,7 @@
            visibility = collection['visibility']
 
            # Check anonymous user for linked collection access 
-           anons = User.anonymous(request.remote_ip)
-           if current_user != nil || visibility == 'public' || visibility == anons
+           if current_user != nil || visibility == 'public' || visibility == 'local'
             concat htmlOpen_l.html_safe unless defined?(componentIndex)
 %>
         		<li>

--- a/spec/features/dams_object_spec.rb
+++ b/spec/features/dams_object_spec.rb
@@ -981,6 +981,12 @@ describe "User wants to view simple object for local metadata-only collection" d
     expect(page).to_not have_selector('div.restricted-notice', text: @restricted_note)
   end
 
+  scenario 'curator user should see the collection link' do
+    sign_in_developer
+    visit dams_object_path @metadataOnlyObj.pid
+    expect(page).to have_link('Test UCSD IP only Collection with metadata-only visibility', :href => "#{dams_collection_path @metadataOnlyCollection.pid}")
+  end
+
   scenario 'local user should not see Restricted View label, access text or download link' do
     sign_in_anonymous '132.239.0.3'
     visit dams_object_path @metadataOnlyObj.pid
@@ -989,12 +995,23 @@ describe "User wants to view simple object for local metadata-only collection" d
     expect(page).to_not have_link('', href:"/object/#{@metadataOnlyObj.id}/_1.mp4/download")
   end
 
+  scenario 'local user should see the collection link' do
+    sign_in_anonymous '132.239.0.3'
+    visit dams_object_path @metadataOnlyObj.pid
+    expect(page).to have_link('Test UCSD IP only Collection with metadata-only visibility', :href => "#{dams_collection_path @metadataOnlyCollection.pid}")
+  end
+
   scenario 'public user should see Restricted View access text and no download link' do
     visit dams_object_path @metadataOnlyObj.pid
     expect(page).to have_content('Restricted View')
     expect(page).to have_selector('div.restricted-notice', text: @restricted_note)
     expect(page).to_not have_link('', href:"/object/#{@metadataOnlyObj.id}/_1.mp4/download")
   end 
+
+  scenario 'public user should see the collection link' do
+    visit dams_object_path @metadataOnlyObj.pid
+    expect(page).to have_link('Test UCSD IP only Collection with metadata-only visibility', :href => "#{dams_collection_path @metadataOnlyCollection.pid}")
+  end
 end
 
 describe "User wants to view simple object for public metadata-only collection" do


### PR DESCRIPTION
metadata for public users.

Fixes #521

#### Local Checklist
- [x] Tests written and passing locally?
- [x] Code style checked?
- [ ] QA-ed locally?
- [ ] Rebased with `master` branch?
- [ ] Configuration updated (if needed)?
- [ ] Documentation updated (if needed)?

#### What does this PR do?
Add the missing collection link to UCSD IP/metadata-only objects.

##### Why are we doing this? Any context of related work?
References #521

@ucsdlib/developers - please review
