### PR TITLE
Updated access label for mixed objects collection

### DIFF
--- a/app/helpers/catalog_helper.rb
+++ b/app/helpers/catalog_helper.rb
@@ -103,7 +103,7 @@ module CatalogHelper
       if access_group.include?('local') && !mix_obj && !metadata_colls.include?("#{document['id']}true")
         view_access = 'Restricted to UC San Diego use only'
       elsif metadata_colls.include?("#{document['id']}true") || mix_obj
-        view_access = hide_label?(document) ? nil : 'Some items restricted'
+        view_access = 'Some items restricted'
       elsif metadata_colls.include?(document['id']) || meta_only_obj
         view_access = hide_label?(document) ? nil : 'Restricted View'
       elsif access_group.include?('public')

--- a/spec/features/dams_collections_spec.rb
+++ b/spec/features/dams_collections_spec.rb
@@ -576,15 +576,13 @@ feature "Visitor wants to view a local collection's page with mixed objects" do
     expect(page).to have_content('Some items restricted')
   end
   
-  scenario 'local user should not see access label when visit browse by collection page or search for collection' do
+  scenario 'local user should see access label when visit browse by collection page or search for collection' do
     sign_in_anonymous '132.239.0.3'
     visit '/collections'
-    expect(page).to_not have_content('Restricted View')
-    expect(page).to_not have_content('Some items restricted')
+    expect(page).to have_content('Some items restricted')
 
     visit catalog_index_path( {:q => @localCollection.pid} )
-    expect(page).to_not have_content('Restricted View')
-    expect(page).to_not have_content('Some items restricted')
+    expect(page).to have_content('Some items restricted')
   end
   
   scenario 'curator user should see access label when visit browse by collection page or search for collection' do
@@ -706,15 +704,13 @@ feature "Visitor wants to view a local collection's page with mixed objects" do
     expect(page).to have_content('Some items restricted')
   end
   
-  scenario 'local user should not see access label when visit browse by collection page or search for collection' do
+  scenario 'local user should see access label when visit browse by collection page or search for collection' do
     sign_in_anonymous '132.239.0.3'
     visit '/collections'
-    expect(page).to_not have_content('Restricted View')
-    expect(page).to_not have_content('Some items restricted')
+    expect(page).to have_content('Some items restricted')
 
     visit catalog_index_path( {:q => @localCollection.pid} )
-    expect(page).to_not have_content('Restricted View')
-    expect(page).to_not have_content('Some items restricted')
+    expect(page).to have_content('Some items restricted')
   end
   
   scenario 'curator user should see access label when visit browse by collection page or search for collection' do


### PR DESCRIPTION
#### Local Checklist
- [x] Tests written and passing locally?
- [x] Code style checked?
- [x] QA-ed locally?
- [x] Rebased with `master` branch?
- [ ] Configuration updated (if needed)?
- [ ] Documentation updated (if needed)?

#### What does this PR do?

Change the condition to allow local user to see the access label for collection page when the collection has mixed objects.

@ucsdlib/developers - please review
