### PR TITLE
docker: enable debugging with byebug and friends

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -51,6 +51,7 @@ gem 'coveralls', '0.8.21', require: false
 gem 'rubyzip', '1.2.2'
 
 group :development, :test do
+  gem 'byebug'
   gem 'sass-rails', '~> 5.0.5' # locked
   gem 'coffee-rails', '~> 4.2.1'
   gem 'pry', '~> 0.10.4'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -91,6 +91,7 @@ GEM
       sass (~> 3.2)
     bower-rails (0.11.0)
     builder (3.2.3)
+    byebug (10.0.2)
     cancan (1.6.10)
     capistrano (3.8.1)
       airbrussh (>= 1.0.0)
@@ -442,6 +443,7 @@ DEPENDENCIES
   blacklight_advanced_search (~> 2.2.0)
   bootstrap-sass (~> 2.3.2.2)
   bower-rails (~> 0.11.0)
+  byebug
   capistrano (~> 3.8.1)
   capistrano-bundler (~> 1.2.0)
   capistrano-rails (~> 1.2.3)

--- a/docker/README.md
+++ b/docker/README.md
@@ -32,6 +32,19 @@ container which hosts the damspas application. This can be done as follows:
 - This should only rebuild what is necessary. And won't run `bundle install`
   unless you change the Gemfile
 
+## Debugging w/ byebug
+If you need to use byebug (or similar), ensure you are using the
+`docker/dev/docker-compose.yml` file as it contains support for attaching and
+running a tty in the running container.
+
+If the current web app container is damspas_web_1  then when a byebug breakpoint
+is hit, open a terminal/tab and run:
+```
+docker attach damspas_web_1
+```
+This will give you a prompt for interacting with byebug
+
+
 ## Errors w/ the web container
 
 If you get an error like:

--- a/docker/dev/docker-compose.yml
+++ b/docker/dev/docker-compose.yml
@@ -14,6 +14,8 @@ services:
     env_file:
       - ../.env.dev.database
       - ../.env.dev.web
+    stdin_open: true
+    tty: true
 
   database:
     image: ucsdlib/docker-postgres-damsrepo


### PR DESCRIPTION
Fixes #issuenumber

#### Local Checklist
- [x] QA-ed locally?
- [x] Configuration updated (if needed)?
- [x] Documentation updated (if needed)?

#### What does this PR do?
Adds support and documentation for use debuggers like byebug with the docker/compose development environment

##### Why are we doing this? Any context of related work?
This is still new territory for us, and I ran across this issue working on a different project last week. So I thought I would document and add the solution that I found here.

#### Where should a reviewer start?
See [`docker/README.md`](https://github.com/ucsdlib/damspas/blob/c2aeaef13faaaa1aa4137122dd119c89e0b63db5/docker/README.md#debugging-w-byebug) for how this would be used in practice

#### Manual testing steps?
- Run a fresh build using the `docker/dev/docker-compose.yml` file.
- Add a `byebug` statement somewhere. Controller, wherever.
- Run the app and get it to trigger the breakpoint
- Follow the instructions for using `docker attach <container>` and try interacting with byebug

@ucsdlib/developers and @orangewolf - please review
