### PR TITLE
Fix logger

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -201,7 +201,7 @@ GEM
     kgio (2.11.0)
     launchy (2.4.3)
       addressable (~> 2.3)
-    logger (1.2.8)
+    logger (1.3.0)
     lograge (0.5.1)
       actionpack (>= 4, < 5.2)
       activesupport (>= 4, < 5.2)

--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -75,6 +75,7 @@ namespace :deploy do
   after :finishing, 'deploy:write_version'
   after :finishing, 'deploy:update_sitemap'
   after :finishing, 'deploy:assets:precompile'
+  after :finishing, 'deploy:migrate'
   after :finishing, 'deploy:restart'
 
 end


### PR DESCRIPTION
Fixes #572 

#### Local Checklist
- [x] Rebased with `master` branch?

#### What does this PR do?
- Fixes logger gem shenanigans where 1.28 version was pulled from rubygems
- Adds the `deploy:migrations` task after a new deploy is made, but before a restart

##### Why are we doing this? Any context of related work?
References #572 

#### Where should a reviewer start?

@VivianChu - would you be up for helping me test this out on pontos?

@ucsdlib/developers - please review
