### PR TITLE
Add embed url to audio and image

### DIFF
--- a/app/views/dams_objects/_admin_download.html.erb
+++ b/app/views/dams_objects/_admin_download.html.erb
@@ -4,6 +4,9 @@
 	etc_menu_item_class = 'pull-right'
 	embed_glyph =  '<i class="glyphicon glyphicon-share-alt"></i> Embed'.html_safe
 	adl_glyph =  '<i class="glyphicon glyphicon-download-alt"></i> Download File'.html_safe
+  file_format = (defined?(format)) ? "#{format.capitalize}" : ''
+  embed_width = (format == 'audio') ? '629' : '560'
+  embed_height = (format == 'audio') ? '46' : '315'
 %>
 
 <div class="etc-menu">
@@ -27,9 +30,8 @@
   <div class="modal-body">
     <h4>Embed URL</h4>
     <input class="embedCode" readonly="readonly" type="text" onclick="this.focus();this.select()" value="<%=embed_url%>">
-    <h4>Embed Video</h4>
-    <input class="embedCode" readonly="readonly" type="text" onclick="this.focus();this.select()" value='&lt;iframe src="<%=embed_url%>" width="560" height="315" frameborder="0"&gt;&lt;/iframe&gt;'>
-    <p><em>By embedding Digital Collections videos on your site, you are agreeing to our Terms of Service.</em></p>
+    <h4>Embed <%= file_format %></h4>
+    <textarea class="embedCode" readonly="readonly" rows="2" wrap="hard" onclick="this.focus();this.select()">&lt;iframe src="<%=embed_url%>" width="<%= embed_width%>" height="<%= embed_height%>" frameborder="0"&gt;&lt;/iframe&gt;</textarea>
   </div>
   <div class="modal-footer">
     <button class="btn" data-dismiss="modal" aria-hidden="true">Close</button>

--- a/app/views/dams_objects/_audio_viewer.html.erb
+++ b/app/views/dams_objects/_audio_viewer.html.erb
@@ -4,9 +4,10 @@
    cmpid = (defined?(componentIndex)) ? "#{componentIndex}" : '0'
    fieldData = @document["#{prefix}files_tesim"]
    wowzaURL = grabWowzaURL(fieldData,objid,cmpid)
+   embed_url = "#{root_url}embed/#{objid}/#{cmpid}"
+   file_type = grabFileType(grabFileUse)
 %>
 <% if wowzaURL != nil %>
-
   <div id="dams-audio">Loading the player...</div>
 
   <script type="text/javascript">
@@ -32,4 +33,4 @@
   </script>
 
 <% end %>
-<%= render :partial => 'admin_download', :locals => {:downloadFilePath => downloadFilePath, :downloadDerivativePath => downloadDerivativePath  } %>
+<%= render :partial => 'admin_download', :locals => {:downloadFilePath => downloadFilePath, :embedURL => embed_url, :downloadDerivativePath => downloadDerivativePath, :format => file_type  } %>

--- a/app/views/dams_objects/_audio_viewer_complex.html.erb
+++ b/app/views/dams_objects/_audio_viewer_complex.html.erb
@@ -5,6 +5,8 @@
    fieldData = @document["#{prefix}files_tesim"]
    wowzaURL = grabWowzaURL(fieldData,objid,cmpid)
    dataForDynamicLoad = "{\"file_type\":\"audio\",\"display_file_path\":\"\",\"service_file_path\":\"#{wowzaURL}\"}"
+   embed_url = "#{root_url}embed/#{objid}/#{cmpid}"
+   file_type = grabFileType(grabFileUse(:componentIndex=>cmpid))
 %>
 
 <% if access_notice.nil? && wowzaURL != nil %>
@@ -13,4 +15,4 @@
 
 <% end %>
 
-<%= render :partial => 'admin_download', :locals => {:downloadFilePath => downloadFilePath, :downloadDerivativePath => downloadDerivativePath  } if access_notice.nil?%>
+<%= render :partial => 'admin_download', :locals => {:downloadFilePath => downloadFilePath, :cmpID => cmpid, :embedURL => embed_url, :downloadDerivativePath => downloadDerivativePath, :format => file_type  } if access_notice.nil?%>

--- a/app/views/dams_objects/_complex_object_viewer.html.erb
+++ b/app/views/dams_objects/_complex_object_viewer.html.erb
@@ -38,7 +38,8 @@
 			fileType = grabFileType(fileUse)
 			loadFirstComponent = (firstComponent != nil) ? "data=#{i}" : ''
 			source_file = grabSourceFile(:componentIndex=>i)
-
+            objid = @document['id']
+            embed_url = "#{root_url}embed/#{objid}/#{i}" 
 	        if source_file != nil
 	          download_file_path = download_path(ark,"_#{i}_#{source_file}")
               source_file_path = download_path(ark,"_#{i}_#{source_file}")
@@ -69,7 +70,7 @@
 				<div data='<%=dataForDynamicLoad%>'></div>
                             <% end %>
 		    <%= render :partial => 'metadata_component', :locals => {:componentIndex => i} %>
-		    <%= render :partial => 'admin_download', :locals => {:downloadFilePath => download_file_path, :downloadDerivativePath => service_file_path  } if access_notice.nil?%>
+		    <%= render :partial => 'admin_download', :locals => {:embedURL => embed_url, :downloadFilePath => download_file_path, :downloadDerivativePath => service_file_path, :format => fileType  } if access_notice.nil?%>
 
 		  <% elsif fileType == 'audio' %>
 		    <%= render :partial => 'audio_viewer_complex', :locals => {:access_notice => access_notice, :componentIndex => i, :downloadFilePath => download_file_path, :downloadDerivativePath => nil  } %>
@@ -91,7 +92,7 @@
 				<%= render :partial => 'data_viewer', :locals => {:objectType => 'complex', :filePath => service_file_path, :downloadDerivativePath => service_file_path, :sourcefilePath => source_file_path  } if access_notice.nil?%>
 	        <% elsif fileType == 'text' %>
 		      <%= render :partial => 'metadata_component', :locals => {:componentIndex => i, :fileMetadata => true, :fileName => service_file} %>
-			  <%= render :partial => 'text_viewer', :locals => {:objectType => 'complex', :downloadFilePath => download_file_path, :downloadDerivativePath => service_file_path  } if access_notice.nil?%>
+			  <%= render :partial => 'text_viewer', :locals => {:objectType => 'complex', :downloadFilePath => download_file_path, :downloadDerivativePath => service_file_path, :embedURL => embed_url, :format => fileType  } if access_notice.nil?%>
 			<% else %>
 				<%= render :partial => 'metadata_component', :locals => {:componentIndex => i} %>
 				<%= render :partial => 'default_viewer', :locals => {:objectType => 'complex'} %>				

--- a/app/views/dams_objects/_image_viewer.html.erb
+++ b/app/views/dams_objects/_image_viewer.html.erb
@@ -1,4 +1,10 @@
 <% title=render_document_show_field_value(:document=>@document, :field=>'title_tesim') %>
+<% 
+   objid = @document['id']
+   cmpid = (defined?(componentIndex)) ? "#{componentIndex}" : '0'
+   embed_url = "#{root_url}embed/#{objid}/#{cmpid}"
+   file_type = grabFileType(grabFileUse)
+%>
 <% if displayFilePath.length > 0 && getFilesType != "PDF"%>
    <%= link_to image_tag(displayFilePath, :alt => ''), zoomFilePath %>
 <% else %>
@@ -14,4 +20,4 @@
 		<%= link_to image_tag(filePath, :alt => ''), zoomFilePath %>
 	<% end %>
 <% end %>
-<%= render :partial => 'admin_download', :locals => {:downloadFilePath => downloadFilePath, :downloadDerivativePath => downloadDerivativePath} %>
+<%= render :partial => 'admin_download', :locals => {:embedURL => embed_url, :downloadFilePath => downloadFilePath, :downloadDerivativePath => downloadDerivativePath, :format => file_type} %>

--- a/app/views/dams_objects/_text_viewer.html.erb
+++ b/app/views/dams_objects/_text_viewer.html.erb
@@ -1,1 +1,1 @@
-<%= render :partial => 'admin_download', :locals => {:downloadFilePath => downloadFilePath, :downloadDerivativePath => downloadDerivativePath  } %>
+<%= render :partial => 'admin_download', :locals => {:embedURL => embedURL, :downloadFilePath => downloadFilePath, :downloadDerivativePath => downloadDerivativePath, :format => format  } %>

--- a/app/views/dams_objects/_video_viewer.html.erb
+++ b/app/views/dams_objects/_video_viewer.html.erb
@@ -5,6 +5,7 @@
    fieldData = @document["#{prefix}files_tesim"]
    wowzaURL = grabWowzaURL(fieldData,objid,cmpid)
    embed_url = "#{root_url}embed/#{objid}/#{cmpid}"
+   file_type = grabFileType(grabFileUse)
 %>
 
 <% if wowzaURL != nil %>
@@ -29,4 +30,4 @@
   </script>
 
 <% end %>
-<%= render :partial => 'admin_download', :locals => {:cmpID => cmpid, :embedURL => embed_url, :downloadFilePath => downloadFilePath, :downloadDerivativePath => downloadDerivativePath, :wowzaURL => wowzaURL } %>
+<%= render :partial => 'admin_download', :locals => {:cmpID => cmpid, :embedURL => embed_url, :downloadFilePath => downloadFilePath, :downloadDerivativePath => downloadDerivativePath, :wowzaURL => wowzaURL, :format => file_type } %>

--- a/app/views/dams_objects/_video_viewer_complex.html.erb
+++ b/app/views/dams_objects/_video_viewer_complex.html.erb
@@ -6,9 +6,10 @@
    wowzaURL = grabWowzaURL(fieldData,objid,cmpid)
    dataForDynamicLoad = "{\"file_type\":\"video\",\"display_file_path\":\"\",\"service_file_path\":\"#{wowzaURL}\"}"
    embed_url = "#{root_url}embed/#{objid}/#{cmpid}"
+   file_type = grabFileType(grabFileUse(:componentIndex=>cmpid))
 %>
 
 <% if access_notice.nil? && wowzaURL != nil %>
   <video controls="controls" id="dams-video-<%=componentIndex%>" data='<%=dataForDynamicLoad%>'>Loading the player...</video>
 <% end %>
-<%= render :partial => 'admin_download', :locals => {:cmpID => cmpid, :embedURL => embed_url, :downloadFilePath => downloadFilePath, :downloadDerivativePath => downloadDerivativePath, :wowzaURL => wowzaURL  } if access_notice.nil?%>
+<%= render :partial => 'admin_download', :locals => {:cmpID => cmpid, :embedURL => embed_url, :downloadFilePath => downloadFilePath, :downloadDerivativePath => downloadDerivativePath, :wowzaURL => wowzaURL, :format => file_type  } if access_notice.nil?%>

--- a/app/views/dams_objects/embed.html.erb
+++ b/app/views/dams_objects/embed.html.erb
@@ -4,10 +4,16 @@
    prefix = (component_id != '0') ? "component_#{component_id}_" : ''
    field_data = @document["#{prefix}files_tesim"]
    wowza_url = grabWowzaURL(field_data, object_id, component_id)
+   file_type = grabFileType(grabFileUse)
 %>
 
-<% if wowza_url != nil %>
-
+<% if file_type.include?("image") %>
+<%
+  display_file = grabServiceFile
+  display_file_path = (display_file != 'no_display') ? file_path(object_id,"_#{display_file}") : ''
+%>
+  <%= image_tag(display_file_path, :alt => '') %>
+<% elsif wowza_url != nil%>
   <video controls="controls" id="dams-video">Loading the player...</video>
 
   <script type="text/javascript">
@@ -25,6 +31,20 @@
 		  rtmp: {bufferlength: 3},
 		  analytics: {enabled: false}
 	  });
+    <% if file_type.include?("audio") %>
+      jwplayer().on('ready', function() {
+        resize('dams-video');
+        window.onresize = function() {
+          resize('dams-video');
+        };    
+      });
+      function resize(id) {
+        let newWidth = 0.94;
+        let parent = document.getElementById(id).parentElement;
+        let currentWidth = parent.offsetWidth;
+        jwplayer(id).resize(currentWidth * newWidth, 40);
+      }
+    <% end %>
   </script>
 
 <% end %>


### PR DESCRIPTION
Fixes #551

#### Local Checklist
- [x] Tests written and passing locally?
- [x] Code style checked?
- [x] QA-ed locally?
- [x] Rebased with `master` branch?
- [ ] Configuration updated (if needed)?
- [ ] Documentation updated (if needed)?

#### What does this PR do?
Update Embed URL to include audio and images

#### Screenshots
//Embed url for simple image object
![embedimage](https://user-images.githubusercontent.com/1864660/50786497-8f349f00-1268-11e9-970a-0fe6d4a31053.png)

//Embed url for simple audio object
![audioembed](https://user-images.githubusercontent.com/1864660/50786547-b2f7e500-1268-11e9-9e13-6e45d72a7848.png)

//Embed url for complex audio object
![audiocomplexembed](https://user-images.githubusercontent.com/1864660/50786565-bb502000-1268-11e9-8a67-6341a74b017b.png)

//Embed url for simple video object
![videoembed](https://user-images.githubusercontent.com/1864660/50786590-d1f67700-1268-11e9-927e-69efe5db210d.png)

//Embed url for complex video object
![videocomplexembed](https://user-images.githubusercontent.com/1864660/50786612-e3d81a00-1268-11e9-9dd5-8e98317f29cf.png)

#### Deployment Instructions

@ucsdlib/developers - please review
