### PR TITLE
Add Whenever to capistrano deploy

### DIFF
--- a/Capfile
+++ b/Capfile
@@ -21,6 +21,7 @@ require 'capistrano/rbenv'
 require 'capistrano/bundler'
 # require 'capistrano/rails/assets'
 require 'capistrano/rails/migrations'
+require "whenever/capistrano"
 
 # Loads custom tasks from `lib/capistrano/tasks' if you have any defined.
 Dir.glob('lib/capistrano/tasks/*.cap').each { |r| import r }


### PR DESCRIPTION
This simple PR only adds the whenever deployment to make the background processes run.