### PR TITLE
fix nil error for work auth w/o user, make sure queue counts are not cached in dashboard

### DIFF
--- a/app/views/aeon/queues/errors.html.erb
+++ b/app/views/aeon/queues/errors.html.erb
@@ -12,7 +12,7 @@
         <%= work_authorization.work_pid %>
       </td>
       <td>
-        <%= work_authorization.user.email %>
+        <%= work_authorization.user.try(:email) %>
       </td>
       <td>
         <%= work_authorization.aeon_id %>

--- a/app/views/aeon/queues/index.html.erb
+++ b/app/views/aeon/queues/index.html.erb
@@ -14,7 +14,7 @@
     <% @aeon_queues.each do |aeon_queue| %>
       <tr>
         <td><%= link_to aeon_queue.name, aeon_queue_path(aeon_queue.id) %></td>
-        <td><%= aeon_queue.requests.size %>
+        <td><%= aeon_queue.requests(true).size %>
       </tr>
     <% end %>
     <tr>


### PR DESCRIPTION
This fixes a nil exception when viewing the errors page. The issue here is that "Notch8" is not a valid email address, thus no user gets created, but the view was counting on the user when displaying the work authorization error.  