### PR TITLE
newrelic: enable for staging

### DIFF
--- a/config/newrelic.yml
+++ b/config/newrelic.yml
@@ -40,7 +40,7 @@ pontos:
   <<: *default_settings
   app_name: Pontos damspas
   developer_mode: true
-  
+
 test:
   <<: *default_settings
   # It doesn't make sense to report to New Relic from automated test runs.
@@ -48,6 +48,7 @@ test:
 
 staging:
   <<: *default_settings
+  agent_enabled: true
   app_name: Staging damspas
 
 qa:


### PR DESCRIPTION
Temporarily enable new relic agent on staging environment to try and track down issues
with Notch8 VRR implementation

@ucsdlib/developers - please review
