### PR TITLE
Update iframe width and height for embed image code

### DIFF
--- a/app/helpers/dams_objects_helper.rb
+++ b/app/helpers/dams_objects_helper.rb
@@ -410,6 +410,10 @@ module DamsObjectsHelper
     fieldData = @document["#{prefix}files_tesim"]
   end
 
+  def grabFileSize(parameters={})
+    file_use(parameters,"quality")
+  end
+  
 	#---
 	# Get the source file id value from the component's 'files_tesim' value.
 	#

--- a/app/views/dams_objects/_admin_download.html.erb
+++ b/app/views/dams_objects/_admin_download.html.erb
@@ -1,12 +1,18 @@
 <%
-	component_id = (defined?(cmpID)) ? "#{cmpID}" : ''
-	embed_url = (defined?(embedURL)) ? "#{embedURL}" : ''
+	component_id = (defined?(cmpID)) ? "#{cmpID}" : nil
+	embed_url = (defined?(embedURL)) ? "#{embedURL}" : nil
 	etc_menu_item_class = 'pull-right'
 	embed_glyph =  '<i class="glyphicon glyphicon-share-alt"></i> Embed'.html_safe
 	adl_glyph =  '<i class="glyphicon glyphicon-download-alt"></i> Download File'.html_safe
   file_format = (defined?(format)) ? "#{format.capitalize}" : ''
   embed_width = (format == 'audio') ? '629' : '560'
   embed_height = (format == 'audio') ? '46' : '315'
+  file_size = (format == 'image') ? grabFileSize(:componentIndex=>component_id) : nil
+  if file_size
+    dim = file_size.split("x")
+    embed_width = dim[0]
+    embed_height = dim[1]
+  end
 %>
 
 <div class="etc-menu">

--- a/app/views/dams_objects/_complex_object_viewer.html.erb
+++ b/app/views/dams_objects/_complex_object_viewer.html.erb
@@ -70,7 +70,7 @@
 				<div data='<%=dataForDynamicLoad%>'></div>
                             <% end %>
 		    <%= render :partial => 'metadata_component', :locals => {:componentIndex => i} %>
-		    <%= render :partial => 'admin_download', :locals => {:embedURL => embed_url, :downloadFilePath => download_file_path, :downloadDerivativePath => service_file_path, :format => fileType  } if access_notice.nil?%>
+		    <%= render :partial => 'admin_download', :locals => {:cmpID => i, :embedURL => embed_url, :downloadFilePath => download_file_path, :downloadDerivativePath => service_file_path, :format => fileType  } if access_notice.nil?%>
 
 		  <% elsif fileType == 'audio' %>
 		    <%= render :partial => 'audio_viewer_complex', :locals => {:access_notice => access_notice, :componentIndex => i, :downloadFilePath => download_file_path, :downloadDerivativePath => nil  } %>

--- a/spec/features/dams_object_spec.rb
+++ b/spec/features/dams_object_spec.rb
@@ -1410,7 +1410,6 @@ describe "View complex UCSD localDisplay object" do
       expect(page).to have_content('Embed URL')
       expect(page).to have_content('Embed Image')
       expect(page.body).to match(/embed\/#{@localObj.id}\/2/)
-      expect(page).to have_selector('textarea', text: 'width="560" height="315"')
     end
   end
 end
@@ -1667,7 +1666,6 @@ describe "User wants to view an Image object" do
       expect(page).to have_content('Embed URL')
       expect(page).to have_content('Embed Image')
       expect(page.body).to match(/embed\/#{@obj.id}\/0/)
-      expect(page).to have_selector('textarea', text: 'width="560" height="315"')
     end
   end
 end


### PR DESCRIPTION
Fixes #589 

#### Local Checklist
- [x] Tests written and passing locally?
- [x] Code style checked?
- [x] QA-ed locally?
- [x] Rebased with `master` branch?
- [ ] Configuration updated (if needed)?
- [ ] Documentation updated (if needed)?

#### What does this PR do?
Update iframe for embed image code to use the correct width/height value based on the image dimensions.

#### Manual testing steps?
http://libraryqa.ucsd.edu/dc/object/bb80217186
http://libraryqa.ucsd.edu/dc/object/bb7748491v
http://libraryqa.ucsd.edu/dc/object/bb0717941z

#### Screenshots
![embedsimpleimage](https://user-images.githubusercontent.com/1864660/51859620-6c882a00-22ec-11e9-8fe7-25d8e553ad18.png)
![embedcompleximage](https://user-images.githubusercontent.com/1864660/51859621-6c882a00-22ec-11e9-93ba-9caceb77a67a.png)


@ucsdlib/developers - please review
