### PR TITLE
vrr: email links should be https

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -43,7 +43,10 @@ Hydra::Application.configure do
   config.action_mailer.delivery_method = :sendmail
   config.action_mailer.perform_deliveries = true
   config.action_mailer.raise_delivery_errors = true
-  config.action_mailer.default_url_options = {host: 'library.ucsd.edu'}
+  config.action_mailer.default_url_options = {
+    host: 'library.ucsd.edu',
+    protocol: 'https'
+  }
 
 
   # Use a different logger for distributed setups

--- a/config/environments/staging.rb
+++ b/config/environments/staging.rb
@@ -30,7 +30,10 @@ Hydra::Application.configure do
   config.action_mailer.delivery_method = :sendmail
   config.action_mailer.perform_deliveries = true
   config.action_mailer.raise_delivery_errors = true
-  config.action_mailer.default_url_options = {host: 'librarytest.ucsd.edu'}
+  config.action_mailer.default_url_options = {
+    host: 'librarytest.ucsd.edu',
+    protocol: 'https'
+  }
 
   # Enable locale fallbacks for I18n (makes lookups for any locale fall back to
   # the I18n.default_locale when a translation can not be found)


### PR DESCRIPTION
Fixes #646 

This is one part of the solution, hopefully.

Part 1: @jhriv updated the Apache rewrite rule from http -> https to bypass URI encoding
Part 2: Make both staging and production email links use https instead of http

#### Local Checklist
- [ ] Tests written and passing locally?
- [ ] Code style checked?
- [ ] QA-ed locally?
- [ ] Rebased with `master` branch?
- [ ] Configuration updated (if needed)?
- [ ] Documentation updated (if needed)?

@ucsdlib/developers - please review
