### PR TITLE
Add case-insensitive sorting for metadata fields; capitalize first character

### DIFF
--- a/app/views/shared/fields/_anatomy.html.erb
+++ b/app/views/shared/fields/_anatomy.html.erb
@@ -18,8 +18,8 @@
 %>
 
 	  <ul class="unstyled glyphicon-list glyphicon-list-tag">
-	    <% fieldData.each do |topic| %>
-	      <li><%= link_to topic, facet_uri(topic, 'subject_anatomy_sim') %></li>
+	    <% fieldData.sort_by(&:downcase).each do |topic| %>
+	      <li><%= link_to topic.upcase_first, facet_uri(topic, 'subject_anatomy_sim') %></li>
 	    <% end %>
 	  </ul>
 

--- a/app/views/shared/fields/_built_work_place.html.erb
+++ b/app/views/shared/fields/_built_work_place.html.erb
@@ -18,8 +18,8 @@
 %>
 
 	  <ul class="unstyled glyphicon-list glyphicon-list-tag">
-	    <% fieldData.each do |topic| %>
-	      <li><%= link_to topic, facet_uri(topic, 'subject_topic_sim') %></li>
+	    <% fieldData.sort_by(&:downcase).each do |topic| %>
+	      <li><%= link_to topic.upcase_first, facet_uri(topic, 'subject_topic_sim') %></li>
 	    <% end %>
 	  </ul>
 

--- a/app/views/shared/fields/_common_name.html.erb
+++ b/app/views/shared/fields/_common_name.html.erb
@@ -18,8 +18,8 @@
 %>
 
 	  <ul class="unstyled glyphicon-list glyphicon-list-tag">
-	    <% fieldData.each do |topic| %>
-	      <li><%= link_to topic, facet_uri(topic, 'subject_common_name_sim') %></li>
+	    <% fieldData.sort_by(&:downcase).each do |topic| %>
+	      <li><%= link_to topic.upcase_first, facet_uri(topic, 'subject_common_name_sim') %></li>
 	    <% end %>
 	  </ul>
 

--- a/app/views/shared/fields/_conference_name.html.erb
+++ b/app/views/shared/fields/_conference_name.html.erb
@@ -18,8 +18,8 @@
 %>
 
 	  <ul class="unstyled glyphicon-list glyphicon-list-tag">
-	    <% fieldData.each do |topic| %>
-	      <li><%= link_to topic, facet_uri(topic, 'subject_topic_sim') %></li>
+	    <% fieldData.sort_by(&:downcase).each do |topic| %>
+	      <li><%= link_to topic.upcase_first, facet_uri(topic, 'subject_topic_sim') %></li>
 	    <% end %>
 	  </ul>
 

--- a/app/views/shared/fields/_corporate_name.html.erb
+++ b/app/views/shared/fields/_corporate_name.html.erb
@@ -18,8 +18,8 @@
 %>
 
 	  <ul class="unstyled glyphicon-list glyphicon-list-tag">
-	    <% fieldData.each do |topic| %>
-	      <li><%= link_to topic, facet_uri(topic, 'subject_topic_sim') %></li>
+	    <% fieldData.sort_by(&:downcase).each do |topic| %>
+	      <li><%= link_to topic.upcase_first, facet_uri(topic, 'subject_topic_sim') %></li>
 	    <% end %>
 	  </ul>
 

--- a/app/views/shared/fields/_cruise.html.erb
+++ b/app/views/shared/fields/_cruise.html.erb
@@ -18,8 +18,8 @@
 %>
 
 	  <ul class="unstyled glyphicon-list glyphicon-list-tag">
-	    <% fieldData.each do |topic| %>
-	      <li><%= link_to topic, facet_uri(topic, 'subject_cruise_sim') %></li>
+	    <% fieldData.sort_by(&:downcase).each do |topic| %>
+	      <li><%= link_to topic.upcase_first, facet_uri(topic, 'subject_cruise_sim') %></li>
 	    <% end %>
 	  </ul>
 

--- a/app/views/shared/fields/_cultural_context.html.erb
+++ b/app/views/shared/fields/_cultural_context.html.erb
@@ -18,8 +18,8 @@
 %>
 
 	  <ul class="unstyled glyphicon-list glyphicon-list-tag">
-	    <% fieldData.each do |topic| %>
-	      <li><%= link_to topic, facet_uri(topic, 'subject_cultural_context_sim') %></li>
+	    <% fieldData.sort_by(&:downcase).each do |topic| %>
+	      <li><%= link_to topic.upcase_first, facet_uri(topic, 'subject_cultural_context_sim') %></li>
 	    <% end %>
 	  </ul>
 

--- a/app/views/shared/fields/_family_name.html.erb
+++ b/app/views/shared/fields/_family_name.html.erb
@@ -18,8 +18,8 @@
 %>
 
 	  <ul class="unstyled glyphicon-list glyphicon-list-tag">
-	    <% fieldData.each do |topic| %>
-	      <li><%= link_to topic, facet_uri(topic, 'subject_topic_sim') %></li>
+	    <% fieldData.sort_by(&:downcase).each do |topic| %>
+	      <li><%= link_to topic.upcase_first, facet_uri(topic, 'subject_topic_sim') %></li>
 	    <% end %>
 	  </ul>
 

--- a/app/views/shared/fields/_function.html.erb
+++ b/app/views/shared/fields/_function.html.erb
@@ -18,8 +18,8 @@
 %>
 
 	  <ul class="unstyled glyphicon-list glyphicon-list-tag">
-	    <% fieldData.each do |topic| %>
-	      <li><%= link_to topic, facet_uri(topic, 'subject_topic_sim') %></li>
+	    <% fieldData.sort_by(&:downcase).each do |topic| %>
+	      <li><%= link_to topic.upcase_first, facet_uri(topic, 'subject_topic_sim') %></li>
 	    <% end %>
 	  </ul>
 

--- a/app/views/shared/fields/_genre_form.html.erb
+++ b/app/views/shared/fields/_genre_form.html.erb
@@ -18,8 +18,8 @@
 %>
 
 	  <ul class="unstyled glyphicon-list glyphicon-list-tag">
-	    <% fieldData.each do |topic| %>
-	      <li><%= link_to topic, facet_uri(topic, 'subject_topic_sim') %></li>
+	    <% fieldData.sort_by(&:downcase).each do |topic| %>
+	      <li><%= link_to topic.upcase_first, facet_uri(topic, 'subject_topic_sim') %></li>
 	    <% end %>
 	  </ul>
 

--- a/app/views/shared/fields/_geographic.html.erb
+++ b/app/views/shared/fields/_geographic.html.erb
@@ -18,8 +18,8 @@
 %>
 
 	  <ul class="unstyled glyphicon-list glyphicon-list-tag">
-	    <% fieldData.each do |topic| %>
-	      <li><%= link_to topic, facet_uri(topic, 'subject_topic_sim') %></li>
+	    <% fieldData.sort_by(&:downcase).each do |topic| %>
+	      <li><%= link_to topic.upcase_first, facet_uri(topic, 'subject_topic_sim') %></li>
 	    <% end %>
 	  </ul>
 

--- a/app/views/shared/fields/_iconography.html.erb
+++ b/app/views/shared/fields/_iconography.html.erb
@@ -18,8 +18,8 @@
 %>
 
 	  <ul class="unstyled glyphicon-list glyphicon-list-tag">
-	    <% fieldData.each do |topic| %>
-	      <li><%= link_to topic, facet_uri(topic, 'subject_topic_sim') %></li>
+	    <% fieldData.sort_by(&:downcase).each do |topic| %>
+	      <li><%= link_to topic.upcase_first, facet_uri(topic, 'subject_topic_sim') %></li>
 	    <% end %>
 	  </ul>
 

--- a/app/views/shared/fields/_language.html.erb
+++ b/app/views/shared/fields/_language.html.erb
@@ -21,31 +21,29 @@
 	 	if lang.count > 0
 	 		htmlOpen %= 'Language'.pluralize(lang.count)
 	 		concat htmlOpen.html_safe
-	 		i = 0
-	 		while( i < lang.count )
+      lang.sort_by(&:downcase).each do |l|
 %>
-					<li><%= lang[i] %></li>
+        <li><%= l.upcase_first %></li>
 <%
-				i += 1
-			end
+      end
 		end
 		concat htmlClose.html_safe
 
-	else 
+	else
 		language = @document["#{prefix}language_tesim"]
 
 		 if (language != nil && language.first.downcase != "no linguistic content")
-	
+
 			 htmlOpen %= 'Language'
 			 concat htmlOpen.html_safe
 %>
-	
+
 					<li><%= language.first %></li>
 
 <%
 			 concat htmlClose.html_safe
-	
+
 		 end
-		
+
 	end
 %>

--- a/app/views/shared/fields/_lithology.html.erb
+++ b/app/views/shared/fields/_lithology.html.erb
@@ -18,8 +18,8 @@
 %>
 
 	  <ul class="unstyled glyphicon-list glyphicon-list-tag">
-	    <% fieldData.each do |topic| %>
-	      <li><%= link_to topic, facet_uri(topic, 'subject_lithology_sim') %></li>
+	    <% fieldData.sort_by(&:downcase).each do |topic| %>
+	      <li><%= link_to topic.upcase_first, facet_uri(topic, 'subject_lithology_sim') %></li>
 	    <% end %>
 	  </ul>
 

--- a/app/views/shared/fields/_name.html.erb
+++ b/app/views/shared/fields/_name.html.erb
@@ -16,10 +16,10 @@
 		 htmlOpen %= 'Other Name'.pluralize(fieldData.count)
 		 concat htmlOpen.html_safe
 
-		 fieldData.each do |datum|
+		 fieldData.sort_by(&:downcase).each do |datum|
 	 		name = datum
 %>
-		<li><%= name %></li>
+		<li><%= name.upcase_first %></li>
 <%
 		 end
 

--- a/app/views/shared/fields/_occupation.html.erb
+++ b/app/views/shared/fields/_occupation.html.erb
@@ -18,8 +18,8 @@
 %>
 
 	  <ul class="unstyled glyphicon-list glyphicon-list-tag">
-	    <% fieldData.each do |topic| %>
-	      <li><%= link_to topic, facet_uri(topic, 'subject_topic_sim') %></li>
+	    <% fieldData.sort_by(&:downcase).each do |topic| %>
+	      <li><%= link_to topic.upcase_first, facet_uri(topic, 'subject_topic_sim') %></li>
 	    <% end %>
 	  </ul>
 

--- a/app/views/shared/fields/_personal_name.html.erb
+++ b/app/views/shared/fields/_personal_name.html.erb
@@ -18,8 +18,8 @@
 %>
 
 	  <ul class="unstyled glyphicon-list glyphicon-list-tag">
-	    <% fieldData.each do |topic| %>
-	      <li><%= link_to topic, facet_uri(topic, 'subject_topic_sim') %></li>
+	    <% fieldData.sort_by(&:downcase).each do |topic| %>
+	      <li><%= link_to topic.upcase_first, facet_uri(topic, 'subject_topic_sim') %></li>
 	    <% end %>
 	  </ul>
 

--- a/app/views/shared/fields/_relationships_data.html.erb
+++ b/app/views/shared/fields/_relationships_data.html.erb
@@ -4,8 +4,8 @@
 %>
 
 	<ul class="unstyled glyphicon-list glyphicon-list-tag">
-		<% value.sort.each do |name| %>
-			<li><%= link_to name, facet_uri(name, 'creator_sim') %></li>
+		<% value.each do |name| %>
+			<li><%= link_to name.upcase_first, facet_uri(name, 'creator_sim') %></li>
 		<% end %>
 	</ul>
 

--- a/app/views/shared/fields/_resource_type.html.erb
+++ b/app/views/shared/fields/_resource_type.html.erb
@@ -10,7 +10,7 @@ if @document['resource_type_tesim'] != nil && !defined?(componentIndex)
 </dt>
 <dd>
   <ul class='unstyled glyphicon-list glyphicon-list-tag'>
-    <% fieldData.each do |resource_type|
+    <% fieldData.sort_by(&:downcase).each do |resource_type|
       facet_uri_list['f'].merge!({'object_type_sim'=>["#{resource_type}"]}) %>
       <li><%= link_to resource_type, facet_uri_list %></li>
     <% end %>

--- a/app/views/shared/fields/_rights_holder.html.erb
+++ b/app/views/shared/fields/_rights_holder.html.erb
@@ -16,10 +16,10 @@
 		 htmlOpen %= 'Rights Holder'.pluralize(fieldData.count)
 		 concat htmlOpen.html_safe
 
-		 fieldData.each do |datum|
+		 fieldData.sort_by(&:downcase).each do |datum|
 			 rightsHolder = datum
 %>
-		<li><%= rightsHolder %></li>
+		<li><%= rightsHolder.upcase_first %></li>
 	<%
 		 end
 

--- a/app/views/shared/fields/_scientific_name.html.erb
+++ b/app/views/shared/fields/_scientific_name.html.erb
@@ -18,8 +18,8 @@
 %>
 
 	  <ul class="unstyled glyphicon-list glyphicon-list-tag">
-	    <% fieldData.each do |topic| %>
-	      <li><%= link_to topic, facet_uri(topic, 'subject_scientific_name_sim') %></li>
+	    <% fieldData.sort_by(&:downcase).each do |topic| %>
+	      <li><%= link_to topic.upcase_first, facet_uri(topic, 'subject_scientific_name_sim') %></li>
 	    <% end %>
 	  </ul>
 

--- a/app/views/shared/fields/_series.html.erb
+++ b/app/views/shared/fields/_series.html.erb
@@ -18,8 +18,8 @@
 %>
 
 	  <ul class="unstyled glyphicon-list glyphicon-list-tag">
-	    <% fieldData.each do |topic| %>
-	      <li><%= link_to topic, facet_uri(topic, 'subject_series_sim') %></li>
+	    <% fieldData.sort_by(&:downcase).each do |topic| %>
+	      <li><%= link_to topic.upcase_first, facet_uri(topic, 'subject_series_sim') %></li>
 	    <% end %>
 	  </ul>
 

--- a/app/views/shared/fields/_style_period.html.erb
+++ b/app/views/shared/fields/_style_period.html.erb
@@ -18,8 +18,8 @@
 %>
 
 	  <ul class="unstyled glyphicon-list glyphicon-list-tag">
-	    <% fieldData.each do |topic| %>
-	      <li><%= link_to topic, facet_uri(topic, 'subject_topic_sim') %></li>
+	    <% fieldData.sort_by(&:downcase).each do |topic| %>
+	      <li><%= link_to topic.upcase_first, facet_uri(topic, 'subject_topic_sim') %></li>
 	    <% end %>
 	  </ul>
 

--- a/app/views/shared/fields/_subject.html.erb
+++ b/app/views/shared/fields/_subject.html.erb
@@ -16,8 +16,6 @@
     fieldData.concat(values) unless values.nil?
   end
 
-  fieldData.sort!
-
   unless fieldData.empty?
 
     htmlOpen %= 'Topic'.pluralize(fieldData.count)
@@ -25,8 +23,8 @@
 %>
 
     <ul class="unstyled glyphicon-list glyphicon-list-tag">
-      <% fieldData.each do |topic| %>
-        <li><%= link_to topic, facet_uri(topic, 'subject_topic_sim') %></li>
+      <% fieldData.sort_by(&:downcase).each do |topic| %>
+        <li><%= link_to topic.upcase_first, facet_uri(topic, 'subject_topic_sim') %></li>
       <% end %>
     </ul>
 

--- a/app/views/shared/fields/_technique.html.erb
+++ b/app/views/shared/fields/_technique.html.erb
@@ -18,8 +18,8 @@
 %>
 
 	  <ul class="unstyled glyphicon-list glyphicon-list-tag">
-	    <% fieldData.each do |topic| %>
-	      <li><%= link_to topic, facet_uri(topic, 'subject_topic_sim') %></li>
+	    <% fieldData.sort_by(&:downcase).each do |topic| %>
+	      <li><%= link_to topic.upcase_first, facet_uri(topic, 'subject_topic_sim') %></li>
 	    <% end %>
 	  </ul>
 

--- a/app/views/shared/fields/_temporal.html.erb
+++ b/app/views/shared/fields/_temporal.html.erb
@@ -18,8 +18,8 @@
 %>
 
 	  <ul class="unstyled glyphicon-list glyphicon-list-tag">
-	    <% fieldData.each do |topic| %>
-	      <li><%= link_to topic, facet_uri(topic, 'subject_topic_sim') %></li>
+	    <% fieldData.sort_by(&:downcase).each do |topic| %>
+	      <li><%= link_to topic.upcase_first, facet_uri(topic, 'subject_topic_sim') %></li>
 	    <% end %>
 	  </ul>
 

--- a/app/views/shared/fields/_title.html.erb
+++ b/app/views/shared/fields/_title.html.erb
@@ -13,37 +13,37 @@
 <% if fieldData != nil %>
 
 	<hgroup>
-	<% fieldData.each do |datum| 
+	<% fieldData.each do |datum|
       result = JSON.parse(datum)
       partName = result['partName'] || ""
       partNumber = result['partNumber'] || ""
       subtitle = result['subtitle'] || ""
       translationVariant = result['translationVariant'] || []
 
-      subtitleVal = subtitle      
+      subtitleVal = subtitle
       if !partName.blank?
-      	subtitleVal += (subtitleVal.blank? ? "" : ", ") + partName     	
+      	subtitleVal += (subtitleVal.blank? ? "" : ", ") + partName
       	subtitleVal += " " + partNumber if !partNumber.blank?
-      end      
-      
+      end
+
       if translationVariant.class == Array
         translationVariant.each do |transV|
           subtitleVal += (subtitleVal.blank? ? "" : ", ") + transV
         end
-      elsif translationVariant.class == String && !translationVariant.blank?      
+      elsif translationVariant.class == String && !translationVariant.blank?
         subtitleVal += (subtitleVal.blank? ? "" : ", ") + translationVariant
       end
-      
+
       if !result['name'].blank?
-         title = result['name'] 
+         title = result['name']
         break
       else
         title = getFullTitle result || ""
       end
-      
+
     end
   %>
-    
+
 	<h1><%= title.html_safe %></h1>
     <h2><%= subtitleVal.html_safe %></h2>
 	</hgroup>

--- a/app/views/shared/fields/_topic.html.erb
+++ b/app/views/shared/fields/_topic.html.erb
@@ -18,8 +18,8 @@
 %>
 
 	  <ul class="unstyled glyphicon-list glyphicon-list-tag">
-	    <% fieldData.each do |topic| %>
-	      <li><%= link_to topic, facet_uri(topic, 'subject_topic_sim') %></li>
+	    <% fieldData.sort_by(&:downcase).each do |topic| %>
+	      <li><%= link_to topic.upcase_first, facet_uri(topic, 'subject_topic_sim') %></li>
 	    <% end %>
 	  </ul>
 

--- a/config/initializers/extensions.rb
+++ b/config/initializers/extensions.rb
@@ -1,0 +1,2 @@
+# Load extentions/monkeypatches
+require "#{Rails.root}/lib/core_extensions/string/inflections"

--- a/lib/core_extensions/string/inflections.rb
+++ b/lib/core_extensions/string/inflections.rb
@@ -1,0 +1,13 @@
+module CoreExtensions
+  module String
+    module Inflections
+      # convert first character to uppercase, leave others along
+      # back-ported from Rails 5: https://github.com/rails/rails/pull/23895
+      def upcase_first
+        self.sub(/\S/, &:upcase)
+      end
+    end
+  end
+end
+
+String.include CoreExtensions::String::Inflections

--- a/spec/features/dams_collections_spec.rb
+++ b/spec/features/dams_collections_spec.rb
@@ -64,7 +64,7 @@ feature 'Visitor wants to look at collections' do
   scenario 'damsProvenanceCollectionPart view with parent collection name and collection from faceting' do
     sign_in_developer
     visit dams_collection_path @part.pid
-    expect(page).to have_link('Sample Provenance Collection') 
+    expect(page).to have_link('Sample Provenance Collection')
     expect(page).to have_link("Sample('s): Assembled Collection")
     expect(page).not_to have_link('Sample Provenance Part', :href => "#{dams_collection_path @part.pid}" )
     expect(page).not_to have_link('curator-only collection')
@@ -89,17 +89,17 @@ feature 'Visitor wants to look at the collection search results view with no iss
     @provCollection = DamsProvenanceCollection.create(pid: "uu8056206n", visibility: "public")
     @provCollection.damsMetadata.content = File.new('spec/fixtures/damsProvenanceCollection3.rdf.xml').read
     @provCollection.save!
-    solr_index (@provCollection.pid)   
+    solr_index (@provCollection.pid)
   end
   after do
     @provCollection.delete
     @unit.delete
-  end 
+  end
   scenario 'should see the collection result page with no issued date' do
     visit catalog_index_path( {:q => "#{@provCollection.pid}"} )
-    expect(page).to have_selector('h3', :text => 'Heavy Metals in the Ocean Insect, Halobates')   
+    expect(page).to have_selector('h3', :text => 'Heavy Metals in the Ocean Insect, Halobates')
     expect(page).to have_selector("ul.dams-search-results-fields:first li span", :text => '1961-1978')
-    expect(page).to have_no_content('1000-2015')     
+    expect(page).to have_no_content('1000-2015')
   end
 end
 
@@ -110,23 +110,23 @@ feature 'Visitor wants to see the collection record' do
     @provCollection = DamsProvenanceCollection.create(pid: "uu8056206n", visibility: "public")
     @provCollection.damsMetadata.content = File.new('spec/fixtures/damsProvenanceCollection3.rdf.xml').read
     @provCollection.save!
-    solr_index (@provCollection.pid)   
+    solr_index (@provCollection.pid)
   end
   after do
     @provCollection.delete
     @unit.delete
     @commonName.delete
-  end 
+  end
 
   scenario 'should see the related resource with no URI' do
     visit dams_collection_path("#{@provCollection.pid}")
     expect(page).to have_content('The physical materials are held at UC San Diego Library')
-    expect(page).not_to have_link('The physical materials are held at UC San Diego Library', {href: ''})    
+    expect(page).not_to have_link('The physical materials are held at UC San Diego Library', {href: ''})
   end
 
   scenario 'should see the names in order' do
     visit dams_collection_path("#{@provCollection.pid}")
-    expect(page).to have_selector("div.span8 dl dt[1]", :text => 'Principal Investigator')  
+    expect(page).to have_selector("div.span8 dl dt[1]", :text => 'Principal Investigator')
     expect(page).to have_selector("div.span8 dl dt[3]", :text => 'Co Principal Investigator')
     expect(page).to have_selector("div.span8 dl dt[5]", :text => 'Creator')
     expect(page).to have_selector("div.span8 dl dt[7]", :text => 'Author')
@@ -140,8 +140,8 @@ feature 'Visitor wants to see the collection record' do
 
   scenario 'should see the internal and external common names' do
     visit dams_collection_path("#{@provCollection.pid}")
-    expect(page).to have_selector('li', text: 'thale-cress')
-    expect(page).to have_selector('li', text: 'thale-cress external')
+    expect(page).to have_selector('li', text: 'Thale-cress')
+    expect(page).to have_selector('li', text: 'Thale-cress external')
   end
 end
 
@@ -308,14 +308,14 @@ feature "Vistor wants to view the OSF API output" do
       solr_index (@provCollection1.pid)
       @provCollection2 = DamsProvenanceCollection.create titleValue: "Sample Provenance Collection", visibility: "public"
       @provCollection2.save!
-      solr_index (@provCollection2.pid)      
+      solr_index (@provCollection2.pid)
     end
     after do
       @provCollection1.delete
       @provCollection2.delete
       @unit.delete
     end
-    
+
     scenario 'should see the following fields' do
       sign_in_developer
       visit osf_api_dams_collection_path @provCollection1.pid
@@ -335,7 +335,7 @@ feature "Vistor wants to view the OSF API output" do
       expect(page).to have_content("Test Scientific Name")
       expect(page).to have_content("Test Corporate Name")
       expect(page).to have_content("Test Corporate Name")
-      expect(page).to have_content("Test Personal Name")      
+      expect(page).to have_content("Test Personal Name")
     end
 
     scenario 'should see the default value of Contributor and Publisher for Data Provider' do
@@ -349,7 +349,7 @@ feature 'Visitor wants to look at the collection item view search results' do
   before do
     @unit = DamsUnit.create(pid: 'bb45454545')
     @unit.damsMetadata.content = File.new('spec/fixtures/damsUnit.rdf.xml').read
-    @unit.save!    
+    @unit.save!
     @aCollection = DamsAssembledCollection.create(pid: "xx4473712z", visibility: "public")
     @aCollection.damsMetadata.content = File.new('spec/fixtures/soccomCollection.rdf.xml').read
     @aCollection.save!
@@ -365,8 +365,8 @@ feature 'Visitor wants to look at the collection item view search results' do
     solr_index (@unit.pid)
     solr_index (@aCollection.pid)
     solr_index (@soccomObj1.pid)
-    solr_index (@soccomObj2.pid)   
-    solr_index (@soccomObj3.pid)       
+    solr_index (@soccomObj2.pid)
+    solr_index (@soccomObj3.pid)
   end
   after do
     @aCollection.delete
@@ -374,17 +374,17 @@ feature 'Visitor wants to look at the collection item view search results' do
     @soccomObj1.delete
     @soccomObj2.delete
     @soccomObj3.delete
-  end 
+  end
   scenario 'should not see html tags for any hightlight field in the search result page' do
     visit catalog_index_path( {:q => "#{@aCollection.pid}", 'sort' => 'title_ssi asc'} )
-    expect(page).to have_content('Showing results for 1 - 4 of 4')   
+    expect(page).to have_content('Showing results for 1 - 4 of 4')
     expect(page).to_not have_content("<a href=\"http://library.ucsd.edu/dc/collection/<span class='search-highlight'>#{@aCollection.pid}</span>\">")
   end
 
   scenario 'should see the search result page default sort is title after click "View Collection Items"' do
     visit dams_collection_path("#{@aCollection.pid}")
     first(:link, "View Collection Items").click
-    
+
     expect(page).to have_content("Sort: title")
     expect(page).to_not have_content("Sort: relevance")
   end
@@ -395,9 +395,9 @@ feature "Visitor wants to view a UCSD IP only collection's page with metadata-on
   before(:all) do
     @localDisplay = DamsOtherRight.create permissionType: "localDisplay"
     @metadataDisplay = DamsOtherRight.create permissionType: "metadataDisplay"
-    @metadataOnlyCollection = DamsProvenanceCollection.create titleValue: "Test UCSD IP only Collection with metadata-only visibility", visibility: "local"    
-    @localOnlyCollection = DamsProvenanceCollection.create titleValue: "Test UCSD IP only Collection with localDisplay visibility", visibility: "local"    
-    @collection = DamsProvenanceCollection.create titleValue: "Test UCSD IP only Collection with no localDisplay or metadata-only visibility", visibility: "local"    
+    @metadataOnlyCollection = DamsProvenanceCollection.create titleValue: "Test UCSD IP only Collection with metadata-only visibility", visibility: "local"
+    @localOnlyCollection = DamsProvenanceCollection.create titleValue: "Test UCSD IP only Collection with localDisplay visibility", visibility: "local"
+    @collection = DamsProvenanceCollection.create titleValue: "Test UCSD IP only Collection with no localDisplay or metadata-only visibility", visibility: "local"
     @copyright = DamsCopyright.create status: 'Under copyright'
     @metadataOnlyObj = DamsObject.create titleValue: 'Test Object with metadataOnly Display', copyrightURI: @copyright.pid
     @metadataOnlyObj.otherRightsURI = @metadataDisplay.pid
@@ -409,7 +409,7 @@ feature "Visitor wants to view a UCSD IP only collection's page with metadata-on
     solr_index @metadataDisplay.pid
     solr_index @metadataOnlyCollection.pid
     solr_index @localOnlyCollection.pid
-    solr_index @collection.pid       
+    solr_index @collection.pid
     solr_index @copyright.pid
     solr_index @metadataOnlyObj.pid
     solr_index @localObj.pid
@@ -421,7 +421,7 @@ feature "Visitor wants to view a UCSD IP only collection's page with metadata-on
     @metadataDisplay.delete
     @metadataOnlyCollection.delete
     @localOnlyCollection.delete
-    @collection.delete   
+    @collection.delete
     @copyright.delete
     @metadataOnlyObj.delete
     @localObj.delete
@@ -441,13 +441,13 @@ feature "Visitor wants to view a UCSD IP only collection's page with metadata-on
     visit dams_collection_path @collection.pid
     expect(page).to_not have_content('Restricted View')
   end
-  
+
   scenario 'local user should not see Restricted View access label when visit browse by collection page' do
     sign_in_anonymous '132.239.0.3'
     visit '/collections'
     expect(page).to_not have_content('Restricted View')
   end
-  
+
   scenario 'curator user should not see Restricted View access label' do
     sign_in_developer
     visit catalog_index_path( {:q => @localOnlyCollection.pid} )
@@ -461,11 +461,11 @@ end
 feature "Visitor wants to view a public collection's page with metadata-only objects" do
   before(:all) do
     @metadataDisplay = DamsOtherRight.create permissionType: "metadataDisplay"
-    @publicCollection = DamsProvenanceCollection.create titleValue: "Test Public Collection", visibility: "public"    
+    @publicCollection = DamsProvenanceCollection.create titleValue: "Test Public Collection", visibility: "public"
     @copyright = DamsCopyright.create status: 'Under copyright'
     @metadataOnlyObj = DamsObject.create titleValue: 'Test Object with metadataOnly Display', provenanceCollectionURI: @publicCollection.pid, copyrightURI: @copyright.pid, otherRightsURI: @metadataDisplay.pid
     solr_index @metadataDisplay.pid
-    solr_index @publicCollection.pid      
+    solr_index @publicCollection.pid
     solr_index @copyright.pid
     solr_index @metadataOnlyObj.pid
   end
@@ -482,34 +482,34 @@ feature "Visitor wants to view a public collection's page with metadata-only obj
     visit dams_collection_path @publicCollection.pid
     expect(page).to have_content('Restricted View')
   end
-  
+
   scenario 'curator user should see Restricted View access control information when visit browse by collection page' do
     sign_in_developer
     visit '/collections'
     expect(page).to have_content('Restricted View')
-  end  
+  end
 
   scenario 'local user should see Restricted View access control information' do
     sign_in_anonymous '132.239.0.3'
     visit dams_collection_path @publicCollection.pid
     expect(page).to have_content('Restricted View')
   end
-  
+
   scenario 'local user should see Restricted View access label when visit browse by collection page' do
     sign_in_anonymous '132.239.0.3'
     visit '/collections'
     expect(page).to have_content('Restricted View')
   end
-  
+
   scenario 'public user should see Restricted View access control information' do
     visit dams_collection_path @publicCollection.pid
     expect(page).to have_content('Restricted View')
   end
-  
+
   scenario 'public user should see Restricted View access control information when visit browse by collection page' do
     visit '/collections'
     expect(page).to have_content('Restricted View')
-  end 
+  end
 end
 
 feature "Visitor wants to view a public collection's page with mixed objects" do
@@ -522,7 +522,7 @@ feature "Visitor wants to view a public collection's page with mixed objects" do
     @otherObj = DamsObject.create titleValue: 'Test Object', provenanceCollectionURI: @publicCollection.pid, copyrightURI: @copyright.pid, otherRightsURI: @display.pid
     solr_index @display.pid
     solr_index @metadataDisplay.pid
-    solr_index @publicCollection.pid      
+    solr_index @publicCollection.pid
     solr_index @copyright.pid
     solr_index @metadataOnlyObj.pid
     solr_index @otherObj.pid
@@ -542,7 +542,7 @@ feature "Visitor wants to view a public collection's page with mixed objects" do
     expect(page).to_not have_content('Restricted View')
     expect(page).to have_content('Some items restricted')
   end
-  
+
   scenario 'public user should see some items restricted access information when visit browse by collection page' do
     visit '/collections'
     expect(page).to_not have_content('Restricted View')
@@ -554,7 +554,7 @@ feature "Visitor wants to view a public collection's page with mixed objects" do
     expect(page).to_not have_content('Restricted View')
     expect(page).to have_content('Some items restricted')
   end
-  
+
   scenario 'local user should see access label when visit browse by collection page or search for collection' do
     sign_in_anonymous '132.239.0.3'
     visit '/collections'
@@ -563,7 +563,7 @@ feature "Visitor wants to view a public collection's page with mixed objects" do
     visit catalog_index_path( {:q => @publicCollection.pid} )
     expect(page).to have_content('Some items restricted')
   end
-  
+
   scenario 'curator user should see access label when visit browse by collection page or search for collection' do
     sign_in_developer
     visit '/collections'
@@ -584,7 +584,7 @@ feature "Visitor wants to view a local collection's page with mixed objects" do
     @otherObj = DamsObject.create titleValue: 'Test Object', provenanceCollectionURI: @localCollection.pid, copyrightURI: @copyright.pid, otherRightsURI: @otherRight.pid
     solr_index @license.pid
     solr_index @otherRight.pid
-    solr_index @localCollection.pid      
+    solr_index @localCollection.pid
     solr_index @copyright.pid
     solr_index @localObj.pid
     solr_index @otherObj.pid
@@ -604,19 +604,19 @@ feature "Visitor wants to view a local collection's page with mixed objects" do
     expect(page).to_not have_content('Restricted View')
     expect(page).to have_content('Some items restricted')
   end
-  
+
   scenario 'public user should see some items restricted access information when visit browse by collection page' do
     visit '/collections'
     expect(page).to_not have_content('Restricted View')
     expect(page).to have_content('Some items restricted')
   end
-  
+
   scenario 'public user should see some items restricted access information when search for collection' do
     visit catalog_index_path( {:q => @localCollection.pid} )
     expect(page).to_not have_content('Restricted View')
     expect(page).to have_content('Some items restricted')
   end
-  
+
   scenario 'local user should see access label when visit browse by collection page or search for collection' do
     sign_in_anonymous '132.239.0.3'
     visit '/collections'
@@ -625,7 +625,7 @@ feature "Visitor wants to view a local collection's page with mixed objects" do
     visit catalog_index_path( {:q => @localCollection.pid} )
     expect(page).to have_content('Some items restricted')
   end
-  
+
   scenario 'curator user should see access label when visit browse by collection page or search for collection' do
     sign_in_developer
     visit '/collections'
@@ -633,7 +633,7 @@ feature "Visitor wants to view a local collection's page with mixed objects" do
 
     visit catalog_index_path( {:q => @localCollection.pid} )
     expect(page).to have_content('Some items restricted')
-  end  
+  end
 end
 
 feature "Visitor wants to view a metadata-only public collection's page with no mixed objects" do
@@ -646,7 +646,7 @@ feature "Visitor wants to view a metadata-only public collection's page with no 
     @otherObj = DamsObject.create titleValue: 'Test Object', provenanceCollectionURI: @publicCollection.pid, copyrightURI: @copyright.pid, otherRightsURI: @display.pid
     solr_index @display.pid
     solr_index @metadataDisplay.pid
-    solr_index @publicCollection.pid      
+    solr_index @publicCollection.pid
     solr_index @copyright.pid
     solr_index @metadataOnlyObj.pid
     solr_index @otherObj.pid
@@ -660,25 +660,25 @@ feature "Visitor wants to view a metadata-only public collection's page with no 
     @metadataOnlyObj.delete
     @otherObj.delete
   end
-  
+
   scenario 'public user should not see some items restricted information' do
     visit dams_collection_path @publicCollection.pid
     expect(page).to have_content('Restricted View')
     expect(page).to_not have_content('Some items restricted')
   end
-  
+
   scenario 'public user should not see some items restricted access information when visit browse by collection page' do
     visit '/collections'
     expect(page).to have_content('Restricted View')
     expect(page).to_not have_content('Some items restricted')
   end
-  
+
   scenario 'public user should not see some items restricted access information when search for collection' do
     visit catalog_index_path( {:q => @publicCollection.pid} )
     expect(page).to have_content('Restricted View')
     expect(page).to_not have_content('Some items restricted')
   end
-  
+
   scenario 'local user should see access label when visit browse by collection page or search for collection' do
     sign_in_anonymous '132.239.0.3'
     visit '/collections'
@@ -687,7 +687,7 @@ feature "Visitor wants to view a metadata-only public collection's page with no 
     visit catalog_index_path( {:q => @publicCollection.pid} )
     expect(page).to have_content('Restricted View')
   end
-  
+
   scenario 'curator user should see access label when visit browse by collection page or search for collection' do
     sign_in_developer
     visit '/collections'
@@ -695,7 +695,7 @@ feature "Visitor wants to view a metadata-only public collection's page with no 
 
     visit catalog_index_path( {:q => @publicCollection.pid} )
     expect(page).to have_content('Restricted View')
-  end 
+  end
 end
 
 feature "Visitor wants to view a local collection's page with mixed objects" do
@@ -707,10 +707,10 @@ feature "Visitor wants to view a local collection's page with mixed objects" do
     @otherObj = DamsObject.create titleValue: 'UCSD IP / Campus Access Only', provenanceCollectionURI: @localCollection.pid, copyrightURI: @copyright.pid, otherRightsURI: @localDisplay.pid
     @dogObj = DamsObject.create titleValue: 'Curator and Dogs Only', provenanceCollectionURI: @localCollection.pid, copyrightURI: @copyright.pid, otherRightsURI: @otherRight.pid
     @catObj = DamsObject.create titleValue: 'Curator and Cats Only', provenanceCollectionURI: @localCollection.pid, copyrightURI: @copyright.pid, otherRightsURI: @otherRight.pid
-    
+
     solr_index @otherRight.pid
     solr_index @localDisplay.pid
-    solr_index @localCollection.pid      
+    solr_index @localCollection.pid
     solr_index @copyright.pid
     solr_index @otherObj.pid
     solr_index @dogObj.pid
@@ -732,19 +732,19 @@ feature "Visitor wants to view a local collection's page with mixed objects" do
     expect(page).to_not have_content('Restricted View')
     expect(page).to have_content('Some items restricted')
   end
-  
+
   scenario 'public user should see some items restricted access information when visit browse by collection page' do
     visit '/collections'
     expect(page).to_not have_content('Restricted View')
     expect(page).to have_content('Some items restricted')
   end
-  
+
   scenario 'public user should see some items restricted access information when search for collection' do
     visit catalog_index_path( {:q => @localCollection.pid} )
     expect(page).to_not have_content('Restricted View')
     expect(page).to have_content('Some items restricted')
   end
-  
+
   scenario 'local user should see access label when visit browse by collection page or search for collection' do
     sign_in_anonymous '132.239.0.3'
     visit '/collections'
@@ -753,7 +753,7 @@ feature "Visitor wants to view a local collection's page with mixed objects" do
     visit catalog_index_path( {:q => @localCollection.pid} )
     expect(page).to have_content('Some items restricted')
   end
-  
+
   scenario 'curator user should see access label when visit browse by collection page or search for collection' do
     sign_in_developer
     visit '/collections'
@@ -761,5 +761,5 @@ feature "Visitor wants to view a local collection's page with mixed objects" do
 
     visit catalog_index_path( {:q => @localCollection.pid} )
     expect(page).to have_content('Some items restricted')
-  end  
+  end
 end

--- a/spec/features/dams_object_spec.rb
+++ b/spec/features/dams_object_spec.rb
@@ -584,8 +584,8 @@ describe "complex object view" do
   end
   it "should display iternal and external reference common names in object level and components" do
     visit dams_object_path(@damsComplexObj.pid)
-    expect(page).to have_selector('li', text: 'thale-cress')
-    expect(page).to have_selector('li', text: 'thale-cress component')
+    expect(page).to have_selector('li', text: 'Thale-cress')
+    expect(page).to have_selector('li', text: 'Thale-cress component')
   end
 
   it 'should display component pager' do
@@ -1399,7 +1399,7 @@ describe "View complex UCSD localDisplay object" do
     expect(page).to have_content('Generic Component Title 2')
     expect(page).to have_link('', href:"/object/#{@localObj.id}/_2_1.tif/download?access=curator")
   end
-  
+
   scenario 'show a popup embed modal when user clicks on embed link' do
     sign_in_developer
     visit dams_object_path @localObj.pid
@@ -1661,14 +1661,14 @@ describe "User wants to view an Image object" do
     Capybara.javascript_driver = :poltergeist
     Capybara.current_driver = Capybara.javascript_driver
     sign_in_developer
-    visit dams_object_path @obj.pid  
+    visit dams_object_path @obj.pid
     click_link 'Embed'
     within('.modal-body') do
       expect(page).to have_content('Embed URL')
       expect(page).to have_content('Embed Image')
       expect(page.body).to match(/embed\/#{@obj.id}\/0/)
     end
-  end  
+  end
   scenario 'have image alt text' do
     sign_in_developer
     visit dams_object_path @obj.pid
@@ -1680,7 +1680,7 @@ describe "View an object that has DOI identifier" do
 
   before(:all) do
     @note = { type: "preferred citation", value: "UC San Diego Library Digital Collections. http://doi.org/10.5072/FK12345678"}
- 
+
     @doiObj = DamsObject.create titleValue: 'Test Object with DOI minted', note_attributes: [@note], copyright_attributes: [{status: 'Public'}]
 
     solr_index @doiObj.pid
@@ -1700,7 +1700,7 @@ end
 
 describe "View an object that has no DOI identifier" do
 
-  before(:all) do 
+  before(:all) do
     @noDoiObj = DamsObject.create titleValue: 'Test Object with no DOI minted', copyright_attributes: [{status: 'Public'}]
 
     solr_index @noDoiObj.pid


### PR DESCRIPTION
Fixes #633 

#### Local Checklist
- [x] Tests written and passing locally?
- [x] Code style checked?
- [x] QA-ed locally?
- [x] Rebased with `master` branch?
- [ ] Configuration updated (if needed)?
- [ ] Documentation updated (if needed)?

#### What does this PR do?
- Creates an `upcase_first` method this is backported from Rails 5, which supports the request from @ucsdlib/domm that the lists are normalized to capitalization. See screenshots below for an example of the difference
- Update view partials to sort fields case-insentively
- Update view partials to use `upcase_first` when rendering the text for the field
- Fix a few tests that broke with this new requirement of capitalization

##### Why are we doing this? Any context of related work?
References #633 

#### Screenshots
Before `upcase_first` (sorted, but leaving metadata values as-is)

![pic-selected-190619-1010-06](https://user-images.githubusercontent.com/67506/59786548-57506f80-927c-11e9-82b4-6f89bda60070.png)

With `upcase_first` and sorted case-insensitively

![pic-selected-190619-1012-09](https://user-images.githubusercontent.com/67506/59786556-5c152380-927c-11e9-957a-eabaae4337a7.png)

@ucsdlib/developers - please review
