### PR TITLE
fields: add more ordered names

### DIFF
--- a/app/views/shared/fields/_relationships.html.erb
+++ b/app/views/shared/fields/_relationships.html.erb
@@ -1,28 +1,38 @@
 <%
-	if defined?(componentIndex) # Then we're working with a component
-		prefix = "component_#{componentIndex}_"
-		htmlOpen = '<tr><td>%s</td><td>'
-		htmlClose = '</td></tr>'
-	else # We're working with an object or collection
-		prefix = ''
-		htmlOpen = '<dt>%s</dt><dd>'
-		htmlClose = '</dd>'
-	end
-  
-    names = ['Principal investigator','principal investigator','Co-principal investigator','co-principal investigator', 'Creator', 'creator']	
-	fieldData = @document["#{prefix}relationship_json_tesim"] || {}
-%>
-    <% fieldData.each do |datum| %>
-    <% relationship = JSON.parse(datum).sort.to_h %>
-        <% names.each do |n| %>
-            <% if relationship.has_key?(n)%>
-                <%= render :partial => 'shared/fields/relationships_data', :locals => {key: n, value: relationship[n], htmlOpen: htmlOpen, htmlClose: htmlClose} %>
-                <% relationship.delete(n) %>
-		    <% end %>
-	    <% end %>
-        <% relationship.each do |key, value| %>
-            <%= render :partial => 'shared/fields/relationships_data', :locals => {key: key, value: value, htmlOpen: htmlOpen, htmlClose: htmlClose} %>
-        <% end %>
-    <% end %>
+if defined?(componentIndex) # Then we're working with a component
+  prefix = "component_#{componentIndex}_"
+  htmlOpen = '<tr><td>%s</td><td>'
+  htmlClose = '</td></tr>'
+else # We're working with an object or collection
+  prefix = ''
+  htmlOpen = '<dt>%s</dt><dd>'
+  htmlClose = '</dd>'
+end
 
-		
+
+fieldData = @document["#{prefix}relationship_json_tesim"] || {}
+fieldData.each do |datum|
+  relationship = JSON.parse(datum).sort.to_h
+  ORDERED_ROLES.each do |n|
+    role =
+      if relationship.has_key?(n)
+        n
+      elsif relationship.has_key?(n.upcase_first)
+        n.upcase_first
+      end
+    if role
+%>
+      <%= render :partial => 'shared/fields/relationships_data', :locals => {key: role, value: relationship[role], htmlOpen: htmlOpen, htmlClose: htmlClose} %>
+<%
+      relationship.delete(n)
+    end
+  end
+  relationship.each do |key, value|
+%>
+    <%= render :partial => 'shared/fields/relationships_data', :locals => {key: key, value: value, htmlOpen: htmlOpen, htmlClose: htmlClose} %>
+<%
+   end
+end
+%>
+
+

--- a/config/initializers/ordered_roles.rb
+++ b/config/initializers/ordered_roles.rb
@@ -1,0 +1,1 @@
+ORDERED_ROLES = YAML.safe_load(File.open("#{Rails.root}/config/ordered_roles.yml"))

--- a/config/ordered_roles.yml
+++ b/config/ordered_roles.yml
@@ -1,0 +1,22 @@
+---
+- creator
+- director
+- project director
+- lead
+- author
+- principal investigator
+- co-principal investigator
+- research team head
+- field director
+- laboratory director
+- researcher
+- research team member
+- analyst
+- data contributor
+- data manager
+- field assistant
+- laboratory assistant
+- photographer
+- advisor
+- thesis advisor
+- contributor

--- a/spec/features/dams_collections_spec.rb
+++ b/spec/features/dams_collections_spec.rb
@@ -126,11 +126,13 @@ feature 'Visitor wants to see the collection record' do
 
   scenario 'should see the names in order' do
     visit dams_collection_path("#{@provCollection.pid}")
-    expect(page).to have_selector("div.span8 dl dt[1]", :text => 'Principal Investigator')
-    expect(page).to have_selector("div.span8 dl dt[3]", :text => 'Co Principal Investigator')
-    expect(page).to have_selector("div.span8 dl dt[5]", :text => 'Creator')
-    expect(page).to have_selector("div.span8 dl dt[7]", :text => 'Author')
-    expect(page).to have_selector("div.span8 dl dt[9]", :text => 'Contributors')
+    expect(page).to have_selector("div.span8 dl dt[1]", :text => 'Creator')
+    expect(page).to have_selector("div.span8 dl dt[3]", :text => 'Author')
+    expect(page).to have_selector("div.span8 dl dt[5]", :text => 'Principal Investigator')
+    expect(page).to have_selector("div.span8 dl dt[7]", :text => 'Co Principal Investigator')
+    expect(page).to have_selector("div.span8 dl dt[9]", :text => 'Laboratory Director')
+    expect(page).to have_selector("div.span8 dl dt[11]", :text => 'Thesis Advisor')
+    expect(page).to have_selector("div.span8 dl dt[13]", :text => 'Contributors')
   end
 
   scenario 'should not see access control information (public)' do

--- a/spec/fixtures/damsProvenanceCollection3.rdf.xml
+++ b/spec/fixtures/damsProvenanceCollection3.rdf.xml
@@ -4,8 +4,8 @@
     xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
     xmlns:owl="http://www.w3.org/2002/07/owl#"
     xmlns:dams="http://library.ucsd.edu/ontology/dams#">
-  <dams:ProvenanceCollection rdf:about="http://library.ucsd.edu/ark:/20775/uu8056206n">    
-    <dams:typeOfResource>still image</dams:typeOfResource>   
+  <dams:ProvenanceCollection rdf:about="http://library.ucsd.edu/ark:/20775/uu8056206n">
+    <dams:typeOfResource>still image</dams:typeOfResource>
     <dams:date>
       <dams:Date>
         <dams:type>collected</dams:type>
@@ -15,7 +15,7 @@
         <dams:endDate>1978</dams:endDate>
       </dams:Date>
     </dams:date>
-   
+
     <dams:commonName>
       <dams:CommonName>
         <mads:authoritativeLabel>thale-cress</mads:authoritativeLabel>
@@ -45,16 +45,16 @@
       </dams:Date>
     </dams:date>
     <dams:unit rdf:resource="http://library.ucsd.edu/ark:/20775/xx48484848"/>
-   
+
     <dams:visibility>public</dams:visibility>
-    
+
     <dams:note>
       <dams:Note>
         <rdf:value>Cheng, Lanna; Schulz-Baldes, Meinhard; Alexander, George V; Franco, Paul J; Ott, John (2015): Heavy Metals in the Ocean Insect, Halobates. UC San Diego Library Digital Collections. </rdf:value>
         <dams:type>preferred citation</dams:type>
       </dams:Note>
-    </dams:note>  
-    <dams:typeOfResource>data</dams:typeOfResource>  
+    </dams:note>
+    <dams:typeOfResource>data</dams:typeOfResource>
     <dams:title>
       <mads:Title>
         <mads:authoritativeLabel>Heavy Metals in the Ocean Insect, Halobates</mads:authoritativeLabel>
@@ -77,7 +77,45 @@
         <dams:description>The physical materials are held at UC San Diego Library</dams:description>
         <dams:type>related</dams:type>
       </dams:RelatedResource>
-    </dams:relatedResource>   
+    </dams:relatedResource>
+    <dams:relationship>
+      <dams:Relationship>
+        <dams:personalName>
+          <mads:PersonalName>
+            <mads:authoritativeLabel>Highly, Paid</mads:authoritativeLabel>
+            <mads:elementList rdf:parseType="Collection">
+              <mads:FullNameElement>
+                <mads:elementValue>Highly, Paid</mads:elementValue>
+              </mads:FullNameElement>
+            </mads:elementList>
+          </mads:PersonalName>
+        </dams:personalName>
+        <dams:role>
+          <mads:Authority>
+            <mads:authoritativeLabel>laboratory director</mads:authoritativeLabel>
+          </mads:Authority>
+        </dams:role>
+      </dams:Relationship>
+    </dams:relationship>
+    <dams:relationship>
+      <dams:Relationship>
+        <dams:personalName>
+          <mads:PersonalName>
+            <mads:authoritativeLabel>Credit, I get the</mads:authoritativeLabel>
+            <mads:elementList rdf:parseType="Collection">
+              <mads:FullNameElement>
+                <mads:elementValue>Credit, I get the</mads:elementValue>
+              </mads:FullNameElement>
+            </mads:elementList>
+          </mads:PersonalName>
+        </dams:personalName>
+        <dams:role>
+          <mads:Authority>
+            <mads:authoritativeLabel>thesis advisor</mads:authoritativeLabel>
+          </mads:Authority>
+        </dams:role>
+      </dams:Relationship>
+    </dams:relationship>
     <dams:relationship>
       <dams:Relationship>
         <dams:personalName>
@@ -191,7 +229,7 @@
           </mads:Authority>
         </dams:role>
       </dams:Relationship>
-    </dams:relationship>    
+    </dams:relationship>
     <dams:relationship>
       <dams:Relationship>
         <dams:personalName>
@@ -210,6 +248,6 @@
           </mads:Authority>
         </dams:role>
       </dams:Relationship>
-    </dams:relationship>   
+    </dams:relationship>
   </dams:ProvenanceCollection>
 </rdf:RDF>


### PR DESCRIPTION
Fixes #634 

#### Local Checklist
- [x] Tests written and passing locally?
- [x] Code style checked?
- [ ] QA-ed locally?
- [x] Rebased with `master` branch?
- [x] Configuration updated (if needed)?
- [ ] Documentation updated (if needed)?

#### What does this PR do?
- Extract out ordered roles to a YAML file (loaded via an initializer) to make it easier to adjust
  in the future
- Add a few additional tests for new roles in the ordered listing
- Add a few name/role examples to damsProvenanceCollection3.rdf.xml for
  testing

##### Why are we doing this? Any context of related work?
References #634 - RDCP would like more control over name/role ordering, so hopefully the refactoring work in this ticket of the specified role order to a YAML file will help make any future changes a bit more manageable.

@ucsdlib/developers - please review
