### PR TITLE
VRR - Disable download and embed buttons for authorized works view in…

### DIFF
--- a/app/helpers/dams_objects_helper.rb
+++ b/app/helpers/dams_objects_helper.rb
@@ -718,6 +718,10 @@ def display_node(index)
     end
     nil
   end
+  
+  def vrr_user?
+    return !(current_user && current_user.work_authorizations_count > 0)
+  end
 
   #---
   # Check to see if an object has a "metadataDisplay or localDisplay otherRights"

--- a/app/views/dams_objects/_admin_download.html.erb
+++ b/app/views/dams_objects/_admin_download.html.erb
@@ -15,17 +15,20 @@
   end
 %>
 
-<div class="etc-menu">
 
-  <%= link_to embed_glyph, "#embedLink-#{component_id}", class:etc_menu_item_class, role:'button', :data => { :toggle => 'modal' }, title:'Embed' %>
+  <% if !(current_user && current_user.work_authorizations_count > 0) %>
+    <div class="etc-menu">
 
-  <% if can? :update, @document then %>
-    <%= link_to adl_glyph, downloadFilePath, :rel => 'nofollow', class:etc_menu_item_class, title:'Download File' %>
-  <% elsif can?(:read, @document) && can_download?(@document) && !downloadDerivativePath.nil?%>
-    <%= link_to adl_glyph, downloadDerivativePath, :rel => 'nofollow', class:etc_menu_item_class, title:'Download File' %>
+      <%= link_to embed_glyph, "#embedLink-#{component_id}", class:etc_menu_item_class, role:'button', :data => { :toggle => 'modal' }, title:'Embed' %>
+
+      <% if can? :update, @document then %>
+        <%= link_to adl_glyph, downloadFilePath, :rel => 'nofollow', class:etc_menu_item_class, title:'Download File' %>
+      <% elsif can?(:read, @document) && can_download?(@document) && !downloadDerivativePath.nil?%>
+        <%= link_to adl_glyph, downloadDerivativePath, :rel => 'nofollow', class:etc_menu_item_class, title:'Download File' %>
+      <% end %>
+   </div>
   <% end %>
 
-</div>
 
 <!-- BEGIN_EMBED_MODAL -->
 <div id="embedLink-<%=component_id%>" class="modal hide fade" tabindex="-1" role="dialog" aria-labelledby="embedLinkLabel" aria-hidden="true">

--- a/app/views/dams_objects/_admin_download.html.erb
+++ b/app/views/dams_objects/_admin_download.html.erb
@@ -16,34 +16,33 @@
 %>
 
 
-  <% if !(current_user && current_user.work_authorizations_count > 0) %>
-    <div class="etc-menu">
+<% if !(current_user && current_user.work_authorizations_count > 0) %>
+  <div class="etc-menu">
 
-      <%= link_to embed_glyph, "#embedLink-#{component_id}", class:etc_menu_item_class, role:'button', :data => { :toggle => 'modal' }, title:'Embed' %>
+    <%= link_to embed_glyph, "#embedLink-#{component_id}", class:etc_menu_item_class, role:'button', :data => { :toggle => 'modal' }, title:'Embed' %>
 
-      <% if can? :update, @document then %>
-        <%= link_to adl_glyph, downloadFilePath, :rel => 'nofollow', class:etc_menu_item_class, title:'Download File' %>
-      <% elsif can?(:read, @document) && can_download?(@document) && !downloadDerivativePath.nil?%>
-        <%= link_to adl_glyph, downloadDerivativePath, :rel => 'nofollow', class:etc_menu_item_class, title:'Download File' %>
-      <% end %>
-   </div>
-  <% end %>
-
-
-<!-- BEGIN_EMBED_MODAL -->
-<div id="embedLink-<%=component_id%>" class="modal hide fade" tabindex="-1" role="dialog" aria-labelledby="embedLinkLabel" aria-hidden="true">
-  <div class="modal-header">
-    <button type="button" class="close" data-dismiss="modal" aria-hidden="true">×</button>
-    <h3 id="embedLinkLabel">Embed</h3>
+    <% if can? :update, @document then %>
+      <%= link_to adl_glyph, downloadFilePath, :rel => 'nofollow', class:etc_menu_item_class, title:'Download File' %>
+    <% elsif can?(:read, @document) && can_download?(@document) && !downloadDerivativePath.nil?%>
+      <%= link_to adl_glyph, downloadDerivativePath, :rel => 'nofollow', class:etc_menu_item_class, title:'Download File' %>
+    <% end %>
+ </div>
+  
+  <!-- BEGIN_EMBED_MODAL -->
+  <div id="embedLink-<%=component_id%>" class="modal hide fade" tabindex="-1" role="dialog" aria-labelledby="embedLinkLabel" aria-hidden="true">
+    <div class="modal-header">
+      <button type="button" class="close" data-dismiss="modal" aria-hidden="true">×</button>
+      <h3 id="embedLinkLabel">Embed</h3>
+    </div>
+    <div class="modal-body">
+      <h4>Embed URL</h4>
+      <input class="embedCode" readonly="readonly" type="text" onclick="this.focus();this.select()" value="<%=embed_url%>">
+      <h4>Embed <%= file_format %></h4>
+      <textarea class="embedCode" readonly="readonly" rows="2" wrap="hard" onclick="this.focus();this.select()">&lt;iframe src="<%=embed_url%>" width="<%= embed_width%>" height="<%= embed_height%>" frameborder="0"&gt;&lt;/iframe&gt;</textarea>
+    </div>
+    <div class="modal-footer">
+      <button class="btn" data-dismiss="modal" aria-hidden="true">Close</button>
+    </div>
   </div>
-  <div class="modal-body">
-    <h4>Embed URL</h4>
-    <input class="embedCode" readonly="readonly" type="text" onclick="this.focus();this.select()" value="<%=embed_url%>">
-    <h4>Embed <%= file_format %></h4>
-    <textarea class="embedCode" readonly="readonly" rows="2" wrap="hard" onclick="this.focus();this.select()">&lt;iframe src="<%=embed_url%>" width="<%= embed_width%>" height="<%= embed_height%>" frameborder="0"&gt;&lt;/iframe&gt;</textarea>
-  </div>
-  <div class="modal-footer">
-    <button class="btn" data-dismiss="modal" aria-hidden="true">Close</button>
-  </div>
-</div>
-<!-- /END_EMBED_MODAL -->
+  <!-- /END_EMBED_MODAL -->
+<% end %>

--- a/app/views/dams_objects/_admin_download.html.erb
+++ b/app/views/dams_objects/_admin_download.html.erb
@@ -16,7 +16,7 @@
 %>
 
 
-<% if !(current_user && current_user.work_authorizations_count > 0) %>
+<% if vrr_user? %>
   <div class="etc-menu">
 
     <%= link_to embed_glyph, "#embedLink-#{component_id}", class:etc_menu_item_class, role:'button', :data => { :toggle => 'modal' }, title:'Embed' %>

--- a/app/views/dams_objects/_data_viewer.html.erb
+++ b/app/views/dams_objects/_data_viewer.html.erb
@@ -12,18 +12,20 @@
 		 viewFilePath = filePath.gsub('/download', '')
 	%>
 
-	<div class="form-actions dams-download-button">
-    <% if can?(:edit, @document) || can?(:read, @document) && can_download?(@document)%>
-	    <a id="data-view-file" class="btn <%=btnColor%> pull-right" href="<%= viewFilePath %>"><i class="glyphicon glyphicon-eye-open icon-white"></i> View file</a>
-	    <a id="data-download-file" class="btn btn-link pull-left btn-mini hidden-phone" href="<%= filePath %>" rel="nofollow"><i class="glyphicon glyphicon-download-alt"></i> Download file</a>
-	    <a id="data-download-file-phone" class="btn pull-left btn-mini visible-phone" href="<%= filePath %>" rel="nofollow"><i class="glyphicon glyphicon-download-alt"></i> Download file</a>
-    <% end %>
-    <% if can? :update, @document%>
-	    <% if (defined?(sourcefilePath) && !sourcefilePath.nil? && sourcefilePath != filePath)%>
-	      <a class="btn btn-link pull-left btn-mini hidden-phone" href="<%= sourcefilePath %>" rel="nofollow"><i class="glyphicon glyphicon-download-alt"></i> Download <%= File.extname(sourcefilePath.gsub('/download','')).upcase.gsub('.','')%> source</a>
-	      <a class="btn pull-left btn-mini visible-phone" href="<%= sourcefilePath %>" rel="nofollow"><i class="glyphicon glyphicon-download-alt"></i> Download <%= File.extname(sourcefilePath.gsub('/download','')).upcase.gsub('.','')%> source</a>
-	    <% end %>
-	  <% end %>
-	</div>
-
-<% end %>
+	
+		<% if !(current_user && current_user.work_authorizations_count > 0) %>
+			<div class="form-actions dams-download-button">
+	    	<% if can?(:edit, @document) || can?(:read, @document) && can_download?(@document)%>
+			    <a id="data-view-file" class="btn <%=btnColor%> pull-right" href="<%= viewFilePath %>"><i class="glyphicon glyphicon-eye-open icon-white"></i> View file</a>
+			    <a id="data-download-file" class="btn btn-link pull-left btn-mini hidden-phone" href="<%= filePath %>" rel="nofollow"><i class="glyphicon glyphicon-download-alt"></i> Download file</a>
+			    <a id="data-download-file-phone" class="btn pull-left btn-mini visible-phone" href="<%= filePath %>" rel="nofollow"><i class="glyphicon glyphicon-download-alt"></i> Download file</a>
+	    	<% end %>
+	   	  <% if can? :update, @document%>
+		    	<% if (defined?(sourcefilePath) && !sourcefilePath.nil? && sourcefilePath != filePath)%>
+		      <a class="btn btn-link pull-left btn-mini hidden-phone" href="<%= sourcefilePath %>" rel="nofollow"><i class="glyphicon glyphicon-download-alt"></i> Download <%= File.extname(sourcefilePath.gsub('/download','')).upcase.gsub('.','')%> source</a>
+		      <a class="btn pull-left btn-mini visible-phone" href="<%= sourcefilePath %>" rel="nofollow"><i class="glyphicon glyphicon-download-alt"></i> Download <%= File.extname(sourcefilePath.gsub('/download','')).upcase.gsub('.','')%> source</a>
+		    	<% end %>
+		  	<% end %>
+			</div>
+		<% end %>
+	<% end %>

--- a/app/views/dams_objects/_data_viewer.html.erb
+++ b/app/views/dams_objects/_data_viewer.html.erb
@@ -13,7 +13,7 @@
 	%>
 
 	
-		<% if !(current_user && current_user.work_authorizations_count > 0) %>
+		<% if vrr_user? %>
 			<div class="form-actions dams-download-button">
 	    	<% if can?(:edit, @document) || can?(:read, @document) && can_download?(@document)%>
 			    <a id="data-view-file" class="btn <%=btnColor%> pull-right" href="<%= viewFilePath %>"><i class="glyphicon glyphicon-eye-open icon-white"></i> View file</a>

--- a/spec/features/dams_object_spec.rb
+++ b/spec/features/dams_object_spec.rb
@@ -841,6 +841,7 @@ describe "PDF Viewer" do
     @unit.delete
   end
   it "should show a 'View file' button and a 'Download file' button " do
+    sign_in_curator
     visit dams_object_path(@damsPdfObj.pid)
     expect(page).to have_selector('#data-view-file')
     expect(page).to have_selector('#data-download-file')
@@ -1469,6 +1470,7 @@ describe "User wants to view a simple ucsd-only video" do
   end
 
   scenario 'user should see an embed link' do
+    sign_in_curator
     visit dams_object_path @obj.pid
     expect(page).to have_css("a", :text => "Embed")
   end

--- a/spec/features/dams_object_spec.rb
+++ b/spec/features/dams_object_spec.rb
@@ -1740,6 +1740,7 @@ describe "vrr user who has authorized works should not see Download File and Emb
     solr_index @pdfObj.pid
   end
   after(:all) do
+    @unit.delete
     @imgObj.delete
     @pdfObj.delete
   end

--- a/spec/features/file_spec.rb
+++ b/spec/features/file_spec.rb
@@ -34,6 +34,7 @@ feature "Derivative download" do
     @unit.delete
   end
   scenario 'anonymous user should be able to view and download image file' do
+    sign_in_anonymous '132.239.0.3'
     visit dams_object_path @obj1
     expect(page).to have_selector('h1', text: 'JPEG Test')
     expect(page).to have_link('', href:"/object/#{@obj1.pid}/_1.jpg/download")


### PR DESCRIPTION
Fixes #654 

#### Local Checklist
- [x] Tests written and passing locally?
- [x] Code style checked?
- [x] QA-ed locally?
- [x] Rebased with `master` branch?
- [ ] Configuration updated (if needed)?
- [ ] Documentation updated (if needed)?

#### What does this PR do?
In the authorized user view of a VRR object, remove the download and embed buttons from the object view so authorized VRR users cannot download files or try to generate embed links

##### Why are we doing this? Any context of related work?
References #654

#### Manual testing steps?
Matt Peter and I have tested it on Staging that download and embed wasn't showing up on either the pdf or image objects I had in VRR queues.

@ucsdlib/developers - please review
