### PR TITLE
vrr: support revoking in NewRightsProcessor

### DIFF
--- a/spec/lib/processors/new_rights_processor_spec.rb
+++ b/spec/lib/processors/new_rights_processor_spec.rb
@@ -33,6 +33,22 @@ describe Processors::NewRightsProcessor do
     end
   end
 
+  describe ".revoke_old" do
+    let!(:dams_object){ DamsObject.create(pid: 'revoke_pid', titleValue: 'test_title') }
+    let!(:user){ create_auth_link_user }
+    context "when there are work authorizations to expire" do
+      it "deletes them" do
+        allow_any_instance_of(described_class).to receive(:expire_request).with(anything)
+        Timecop.freeze(Date.today - 31) do
+          WorkAuthorization.create(work_pid: dams_object.pid, aeon_id: '1234567', user: user)
+        end
+        expect(WorkAuthorization.count).to be(1)
+        described_class.revoke_old
+        expect(WorkAuthorization.count).to be(0)
+      end
+    end
+  end
+
   describe "authorize" do
     let!(:dams_object){ DamsObject.create(pid: 'test_pid', titleValue: 'test_title') }
     context "when credentials are valid" do


### PR DESCRIPTION
The previous implementation did not actually test revoking via the
nightly rake task. Examples being:

- Assuming in `initialize` that the attributes were based on a
  `Hashie:Mash` class or subclass, which `Aeon::Request` is, but is not what
was provided in `revoke_old` (was just a simple hash that would blow up immediately when called with messages like `.email`..)
- The work_pid would never be found in `initialize` because
  `subLocation` would not exist in the request attributes supplied by
`revoke_old`

Fixes #667 

#### Local Checklist
- [x] Tests written and passing locally?
- [x] Code style checked?
- [ ] QA-ed locally?
- [x] Rebased with `master` branch?
- [ ] Configuration updated (if needed)?
- [ ] Documentation updated (if needed)?

#### What does this PR do?
Hopefully gets the vrr/aeon nightly `revoke_old` task to actually work.

##### Why are we doing this? Any context of related work?
References #667 - We're doing this because Notch8 did not test this codepath or write tests for it.

#### Where should a reviewer start?
Take a look at the test I wrote. There ended up being a few issues, as illustrated in the commit message. This exercises those issues (needing a `Hashie::Mash` instance _or_ subclass instance, not setting the `work_pid` from a location that wouldn't exist in this context, etc.)

#### Manual testing steps?
We definitely need to test this on staging w/ real records, we currently have 9 that should expire, so that should work well. We also need to make sure this doesn't introduce any regressions, which is theoretically possible since we don't have great test coverage with this work.

@ucsdlib/developers - please review
