### PR TITLE
vrr: fix id assignment in revoke_old

### DIFF
--- a/lib/processors/new_rights_processor.rb
+++ b/lib/processors/new_rights_processor.rb
@@ -25,7 +25,7 @@ module Processors
         begin
           params = Hashie::Mash.new(work_pid: auth.work_pid,
                                     email: auth.user.email,
-                                    aeon_id: auth.aeon_id)
+                                    id: auth.aeon_id)
           request = Processors::NewRightsProcessor.new(params)
           request.revoke
         rescue => e

--- a/spec/lib/processors/new_rights_processor_spec.rb
+++ b/spec/lib/processors/new_rights_processor_spec.rb
@@ -42,9 +42,9 @@ describe Processors::NewRightsProcessor do
         Timecop.freeze(Date.today - 31) do
           WorkAuthorization.create(work_pid: dams_object.pid, aeon_id: '1234567', user: user)
         end
-        expect(WorkAuthorization.count).to be(1)
+        expect(WorkAuthorization.count).to eq(1)
         described_class.revoke_old
-        expect(WorkAuthorization.count).to be(0)
+        expect(WorkAuthorization.count).to eq(0)
       end
     end
   end


### PR DESCRIPTION
The existing code was setting `params.aeon_id` instead of `params.id`, which
ultimately results in a failing submission to the AEON API in
`Aeon::Request.update_status`, which expects the current object to have an
`id` field

Also fixed up the new test, which should really be using an equality comparison rather than the object comparison.

Related to: #667 

#### Local Checklist
- [x] Tests written and passing locally?
- [x] Code style checked?
- [ ] QA-ed locally?
- [x] Rebased with `master` branch?
- [ ] Configuration updated (if needed)?
- [ ] Documentation updated (if needed)?

@ucsdlib/developers - please review
