### PR TITLE
vrr: use rails logger for rest-client

### DIFF
--- a/config/initializers/rest_client_logger.rb
+++ b/config/initializers/rest_client_logger.rb
@@ -1,0 +1,2 @@
+# Teach RestClient instances to use the configured Rails logger
+RestClient.log = Rails.logger


### PR DESCRIPTION
It appears there are issues, yet to be determined, with batch processing vrr expirations.

This patch attaches the [rest-client gem](https://github.com/rest-client/rest-client#logging) to the Rails logger defined for the application. 

This will result in logging when API requests are made, hopefully giving us more insight into what may be going wrong.

Example output:

```
RestClient.get "no_aeon_api_provided/Requests", "Accept"=>"*/*; q=0.5, application/xml", "Accept-Encoding"=>"gzip, deflate", "X-AEON-API-KEY"=>"no_aeon_key_provided", "content-type"=>"text/json"
# => 200 OK |  0 bytes
=> ""
```

#### Local Checklist
- [ ] Tests written and passing locally?
- [ ] Code style checked?
- [x] QA-ed locally?
- [x] Rebased with `master` branch?
- [ ] Configuration updated (if needed)?
- [ ] Documentation updated (if needed)?

@ucsdlib/developers - please review
