### PR TITLE
Fix regression in role ordering

### DIFF
--- a/app/views/shared/fields/_relationships.html.erb
+++ b/app/views/shared/fields/_relationships.html.erb
@@ -14,17 +14,16 @@ fieldData = @document["#{prefix}relationship_json_tesim"] || {}
 fieldData.each do |datum|
   relationship = JSON.parse(datum).sort.to_h
   ORDERED_ROLES.each do |n|
-    role =
-      if relationship.has_key?(n)
-        n
-      elsif relationship.has_key?(n.upcase_first)
-        n.upcase_first
-      end
-    if role
+    if relationship.has_key?(n)
 %>
-      <%= render :partial => 'shared/fields/relationships_data', :locals => {key: role, value: relationship[role], htmlOpen: htmlOpen, htmlClose: htmlClose} %>
+    <%= render :partial => 'shared/fields/relationships_data', :locals => {key: n, value: relationship[n], htmlOpen: htmlOpen, htmlClose: htmlClose} %>
 <%
       relationship.delete(n)
+    elsif relationship.has_key?(n.upcase_first)
+%>
+    <%= render :partial => 'shared/fields/relationships_data', :locals => {key: n.upcase_first, value: relationship[n.upcase_first], htmlOpen: htmlOpen, htmlClose: htmlClose} %>
+<%
+      relationship.delete(n.upcase_first)
     end
   end
   relationship.each do |key, value|

--- a/spec/features/dams_collections_spec.rb
+++ b/spec/features/dams_collections_spec.rb
@@ -135,6 +135,14 @@ feature 'Visitor wants to see the collection record' do
     expect(page).to have_selector("div.span8 dl dt[13]", :text => 'Contributors')
   end
 
+  scenario 'should not see duplicated role names' do
+    visit dams_collection_path("#{@provCollection.pid}")
+    expect(page).to have_link("Cheng, Lanna", count: 1)
+    expect(page).to have_link("Schulz-Baldes, Meinhard", count: 1)
+    expect(page).to have_link("Credit, I get the", count: 1)
+    expect(page).to have_link("Alexander, George V.", count: 1)
+  end
+
   scenario 'should not see access control information (public)' do
     visit dams_collection_path("#{@provCollection.pid}")
     expect(page).to have_no_content('AccessPublic')


### PR DESCRIPTION
The previous implementation was not deleting roles that start with a
capital letter, which was an omission on my part. I've now inlined each condition and explicitly display the partial and delete the relationship as it is found (lowercase, capitalized).

I will also separately raise the issue of why these role values are not normalized. Ideally we shouldn't have to check for capitalization inconsistency.

Related: #634

#### Local Checklist
- [x] Tests written and passing locally?
- [x] Code style checked?
- [x] QA-ed locally?
- [x] Rebased with `master` branch?
- [ ] Configuration updated (if needed)?
- [ ] Documentation updated (if needed)?

@ucsdlib/developers - please review
