### PR TITLE
deploy: restart damsolrizer

### DIFF
--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -45,6 +45,13 @@ namespace :deploy do
     end
   end
 
+  desc 'Restart damsolrizer'
+  task :restart_damsolrizer do
+    on roles(:app), in: :sequence do
+      execute "sh $HOME/bin/damsolrizer.sh"
+    end
+  end
+
   desc "Write the current version to public/version.txt"
   task :write_version do
     on roles(:app), in: :sequence do
@@ -58,5 +65,6 @@ namespace :deploy do
   after :finishing, 'deploy:assets:precompile'
   after :finishing, 'deploy:migrate'
   after :finishing, 'deploy:restart'
+  after :finishing, 'deploy:restart_damsolrizer'
 
 end


### PR DESCRIPTION
Fixes issues we're seeing with damspas deploys and NOT restarting damsolrizer.

Example output on a dry run of capistrano w/ this new task added:

```
~/projects/ucsd/damspas (feature/restart-damsolrizer) % docker-compose -f docker/dev/docker-compose.yml exec web cap production deploy --dry-run
[Deprecation Notice] `set :scm, :git` is deprecated.
To ensure your project is compatible with future versions of Capistrano,
remove the :scm setting and instead add these lines to your Capfile:

    require "capistrano/scm/git"
    install_plugin Capistrano::SCM::Git

00:00 git:wrapper
      01 mkdir -p /tmp
      02 #<StringIO:0x000055974ee47a10> /tmp/git-ssh-damspas-production-.sh
      03 chmod 700 /tmp/git-ssh-damspas-production-.sh
00:00 git:check
      01 git ls-remote https://github.com/ucsdlib/damspas.git HEAD
00:00 deploy:check:directories
      01 mkdir -p /pub/capistrano/shared /pub/capistrano/releases
00:00 git:clone
      The repository mirror is at /pub/capistrano/repo
00:00 git:update
      01 git remote set-url origin https://github.com/ucsdlib/damspas.git
      02 git remote update --prune
00:00 git:create_release
      01 mkdir -p /pub/capistrano/releases/20190703213446
      02 git archive master | /usr/bin/env tar -x -f - -C /pub/capistrano/releases/20190703213446
00:00 deploy:set_current_revision
      01 echo "" >> REVISION
00:00 deploy:migrate
      [deploy:migrate] Run `rake db:migrate`
00:00 deploy:migrating
      01 RBENV_ROOT=$HOME/.rbenv RBENV_VERSION=2.3.7 $HOME/.rbenv/bin/rbenv exec bundle exec rake db:migrate
00:00 whenever:update_crontab
      01 RBENV_ROOT=$HOME/.rbenv RBENV_VERSION=2.3.7 $HOME/.rbenv/bin/rbenv exec bundle exec whenever --update-crontab damspas --set environment=production --roles=web,app,db,sitemap_ping
00:00 deploy:symlink:release
      01 ln -s /pub/capistrano/releases/20190703213446 /pub/capistrano/releases/current
      02 mv /pub/capistrano/releases/current /pub/capistrano
00:00 deploy:write_version
      01 echo `git describe --all --always --long --abbrev=40 HEAD` `date +"%Y-%m-%d %H:%M:%S %Z"`  > /pub/capistrano/releases/20190703213446/public/version.txt
00:00 deploy:update_sitemap
      01 RBENV_ROOT=$HOME/.rbenv RBENV_VERSION=2.3.7 $HOME/.rbenv/bin/rbenv exec bundle exec rake sitemap:refresh
00:00 deploy:assets:precompile
      01 RBENV_ROOT=$HOME/.rbenv RBENV_VERSION=2.3.7 $HOME/.rbenv/bin/rbenv exec bundle exec rake RAILS_RELATIVE_URL_ROOT=/dc assets:precompile
00:00 deploy:restart
      01 mkdir -p /pub/capistrano/releases/20190703213446/tmp
      02 touch /pub/capistrano/releases/20190703213446/tmp/restart.txt
00:00 deploy:restart_damsolrizer
      01 sh $HOME/bin/damsolrizer.sh
00:00 deploy:log_revision
      01 echo "Branch master (at ) deployed as release 20190703213446 by " >> /pub/capistrano/revisions.log
```

#### Deployment test to QA
Damspas deployed with a running version of `damsolrizer`:
```
[conan@lib-hydrahead-qa ~]$ pgrep -f bin/damsolrizer
4619
```
Damspas re-deployed w/ this branch:
```
[conan@lib-hydrahead-qa ~]$ pgrep -f bin/damsolrizer
21057
```

Note, the PID's change, and damsolrizer is still up and running

#### Local Checklist
- [ ] Tests written and passing locally?
- [x] Code style checked?
- [x] QA-ed locally?
- [x] Rebased with `master` branch?
- [ ] Configuration updated (if needed)?
- [ ] Documentation updated (if needed)?

#### What does this PR do?
Adds a capistrano task to restart damsolrizer on deployment.

@ucsdlib/developers - please review
