### PR TITLE
Revert custom RCDP collection sort

### DIFF
--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -309,9 +309,6 @@ class CatalogController < ApplicationController
     unless params[:sort]
       # sort by title
       params[:sort] = 'title_ssi asc'
-      # RDCP prefers their collections sorted by most recently created first
-      # Therefore, we're sorting by modified date rather than title
-      params[:sort] = 'system_modified_dtsi desc, title_ssi asc' if params[:id].eql? 'rdcp'
     end
 
     (@response, @document_list) = get_search_results params, params

--- a/spec/features/collections_search.rb
+++ b/spec/features/collections_search.rb
@@ -20,14 +20,14 @@ feature 'Visitor wants to browse by unit collections' do
       @oldest_collection.delete
       @newest_collection.delete
     end
-    it 'should sort by most recent collection by default, descending to oldest' do
+    xit 'should sort by most recent collection by default, descending to oldest' do
       visit dams_unit_collections_path('rdcp')
       old_collection_sort_order = page.body.index('A Old Collection')
       new_collection_sort_order = page.body.index('The New Collection')
       expect(old_collection_sort_order).to be > new_collection_sort_order
     end
 
-    it 'should still allow user selected sort options' do
+    xit 'should still allow user selected sort options' do
       visit dams_unit_collections_path('rdcp', { sort: 'title_ssi asc' })
       old_collection_sort_order = page.body.index('A Old Collection')
       new_collection_sort_order = page.body.index('The New Collection')


### PR DESCRIPTION
- The system modified date is not acceptable
- Leave tests pending so we can re-use them when we have a better
  solution

References #644 

#### Local Checklist
- [x] Tests written and passing locally?
- [x] Code style checked?
- [ ] QA-ed locally?
- [x] Rebased with `master` branch?
- [ ] Configuration updated (if needed)?
- [ ] Documentation updated (if needed)?

#### What does this PR do?
This revert the change to use the `system_modified_dtsi` field in Solr for sorting RDCP collections. 

It does leave in place the tests that were written, it's just marked them as pending. Hopefully we can enable and reuse these tests once we have a different solution in place.

##### Why are we doing this? Any context of related work?
References #644 

A more appropriate solution is being discussed in #643 and a new PR will be made once we have that sorted out.

@ucsdlib/developers - please review
