### PR TITLE
Generate sitemaps on a schedule, not on deploy

### DIFF
--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -54,26 +54,7 @@ namespace :deploy do
     end
   end
 
-  desc '(re) generate sitemap'
-  task :update_sitemap do
-    on roles(:sitemap_ping), in: :sequence do
-      within release_path do
-        with rails_env: fetch(:rails_env) do
-          execute :rake, 'sitemap:refresh'
-        end
-      end
-    end
-    on roles(:sitemap_noping), in: :sequence do
-      within release_path do
-        with rails_env: fetch(:rails_env) do
-          execute :rake, 'sitemap:refresh:no_ping'
-        end
-      end
-    end
-  end
-
   after :finishing, 'deploy:write_version'
-  after :finishing, 'deploy:update_sitemap'
   after :finishing, 'deploy:assets:precompile'
   after :finishing, 'deploy:migrate'
   after :finishing, 'deploy:restart'

--- a/config/deploy/gimili.rb
+++ b/config/deploy/gimili.rb
@@ -1,6 +1,6 @@
 set :stage, :gimili
 set :branch, (ENV['BRANCH'] || fetch(:branch, 'master'))
-server 'gimili.ucsd.edu', user: 'conan', roles: %w{app db sitemap_noping}
+server 'gimili.ucsd.edu', user: 'conan', roles: %w{app db}
 set :rails_env, "gimili"
 if ENV["CAP_SSHKEY_GIMILI"]
   puts "Using key: #{File.join(ENV["HOME"], ENV["CAP_SSHKEY_GIMILI"])}"

--- a/config/deploy/production.rb
+++ b/config/deploy/production.rb
@@ -1,6 +1,6 @@
 set :stage, :production
 set :branch, (ENV['BRANCH'] || fetch(:branch, 'master'))
-server 'lib-hydrahead-prod.ucsd.edu', user: 'conan', roles: %w{web app db sitemap_ping}
+server 'lib-hydrahead-prod.ucsd.edu', user: 'conan', roles: %w{web app db}
 set :rails_env, "production"
 if ENV["CAP_SSHKEY_PRODUCTION"]
   puts "Using key: #{File.join(ENV["HOME"], ENV["CAP_SSHKEY_PRODUCTION"])}"

--- a/config/deploy/qa.rb
+++ b/config/deploy/qa.rb
@@ -1,7 +1,7 @@
 set :stage, :qa
 set :branch, (ENV['BRANCH'] || fetch(:branch, 'master'))
-server 'lib-hydrahead-qa.ucsd.edu', user: 'conan', roles: %w{web app db sitemap_noping}
-server 'lib-hydratail-qa.ucsd.edu', user: 'conan', roles: %w{web app db sitemap_noping}
+server 'lib-hydrahead-qa.ucsd.edu', user: 'conan', roles: %w{web app db}
+server 'lib-hydratail-qa.ucsd.edu', user: 'conan', roles: %w{web app db}
 set :rails_env, "qa"
 if ENV["CAP_SSHKEY_QA"]
   puts "Using key: #{File.join(ENV["HOME"], ENV["CAP_SSHKEY_QA"])}"

--- a/config/deploy/staging.rb
+++ b/config/deploy/staging.rb
@@ -1,6 +1,6 @@
 set :stage, :staging
 set :branch, (ENV['BRANCH'] || fetch(:branch, 'master'))
-server 'lib-hydrahead-staging.ucsd.edu', user: 'conan', roles: %w{web app db sitemap_noping}
+server 'lib-hydrahead-staging.ucsd.edu', user: 'conan', roles: %w{web app db}
 set :rails_env, "staging"
 if ENV["CAP_SSHKEY_STAGING"]
   puts "Using key: #{File.join(ENV["HOME"], ENV["CAP_SSHKEY_STAGING"])}"

--- a/config/schedule.rb
+++ b/config/schedule.rb
@@ -11,6 +11,9 @@ when 'production'
   every 1.day do
     rake "aeon_requests:revoke_old"
   end
+  every 1.day, at: '2:00 am' do
+    rake "sitemap:refresh"
+  end
 when 'staging'
   every '50 * * * *' do
     rake "aeon_requests:process_new"


### PR DESCRIPTION
While working with @rstanonik on getting capistrano to restart damsolrizer, I realized that the capistrano task to generate sitemaps is taking between 3-5+ minutes on deploys.

Given that the overall time for a deploy is between 7-8 minutes, we're spending a significant percentage, in some cases I clocked it at taking up 80% of the total time.

And the, more important, reality is that updating a sitemap is about **content**, not about things that are generally **deployment** related. We went months without a damspas deploy, and yet DOMM added tons of new objects.

I think a better solution is to put the production environment on a schedule to keep the sitemap up to date.

Resulting crontab will look like:

```
~/projects/ucsd/damspas (feature/sitemap-production-only) % docker-compose -f docker/dev/docker-compose.yml exec web whenever
RAILS_RELATIVE_URL_ROOT=/dc

0 * * * * /bin/bash -l -c 'cd /usr/src/app && RAILS_ENV=production bundle exec rake aeon_requests:process_new --silent'

0 0 * * * /bin/bash -l -c 'cd /usr/src/app && RAILS_ENV=production bundle exec rake aeon_requests:revoke_old --silent'

0 2 * * * /bin/bash -l -c 'cd /usr/src/app && RAILS_ENV=production bundle exec rake sitemap:refresh --silent'

## [message] Above is your schedule file converted to cron syntax; your crontab file was not updated.
## [message] Run `whenever --help' for more options.
```

#### Local Checklist
- [ ] Tests written and passing locally?
- [ ] Code style checked?
- [ ] QA-ed locally?
- [ ] Rebased with `master` branch?
- [ ] Configuration updated (if needed)?
- [ ] Documentation updated (if needed)?

@ucsdlib/developers - please review
