### PR TITLE
gems: add pry-byebug

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -55,7 +55,8 @@ group :development, :test do
   gem 'byebug'
   gem 'sass-rails', '~> 5.0.5' # locked
   gem 'coffee-rails', '~> 4.2.1'
-  gem 'pry', '~> 0.10.4'
+  gem 'pry'
+  gem 'pry-byebug'
   gem 'capybara', '~> 2.14.0'
   gem 'selenium-webdriver', '3.4.0'
   gem 'launchy', '~> 2.4.3'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -283,6 +283,9 @@ GEM
       coderay (~> 1.1.0)
       method_source (~> 0.8.1)
       slop (~> 3.4)
+    pry-byebug (3.6.0)
+      byebug (~> 10.0)
+      pry (~> 0.10)
     public_suffix (3.1.1)
     qa (1.1.0)
       activerecord-import
@@ -493,7 +496,8 @@ DEPENDENCIES
   omniauth-shibboleth (~> 1.2.1)
   pg (~> 0.18.2)
   poltergeist (= 1.15.0)
-  pry (~> 0.10.4)
+  pry
+  pry-byebug
   qa (~> 1.1.0)
   rack-dev-mark (~> 0.7.5)
   rails (~> 4.2.11)


### PR DESCRIPTION
While looking into a few recent tickets I found that we didn't have this gem installed. I prefer the experience of using pry, but it's nice to have byebug integrated for debugging.

@ucsdlib/developers - please review
