### PR TITLE
rdcp created date sorting (Collections) and last modified date display (Objects)

### DIFF
--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -309,6 +309,9 @@ class CatalogController < ApplicationController
     unless params[:sort]
       # sort by title
       params[:sort] = 'title_ssi asc'
+      # RDCP prefers their collections sorted by most recently created first
+      # Therefore, we're sorting by modified date rather than title
+      params[:sort] = 'system_create_dtsi desc' if params[:id].eql? 'rdcp'
     end
 
     (@response, @document_list) = get_search_results params, params

--- a/app/views/shared/fields/_last_modified.html.erb
+++ b/app/views/shared/fields/_last_modified.html.erb
@@ -1,0 +1,11 @@
+<%
+if @document["active_fedora_model_ssi"].eql? "DamsObject"
+  htmlOpen = "<dt>%s</dt><dd>"
+  htmlClose = '</dd>'
+  last_modified = Time.zone.parse(@document["system_modified_dtsi"]).strftime("%Y-%m-%d")
+  htmlOpen %= 'Last Modified'
+  concat htmlOpen.html_safe
+  concat "<p>#{last_modified}</p>".html_safe
+  concat htmlClose.html_safe
+end
+%>

--- a/app/views/shared/fields/_show_raw.erb
+++ b/app/views/shared/fields/_show_raw.erb
@@ -51,7 +51,7 @@
 <%= render :partial => 'shared/fields/note', :locals => {:type => 'arrangement'}.merge(component) %>
 <%= render :partial => 'shared/fields/note', :locals => {:type => 'technical details'}.merge(component) %>
 <%= render :partial => 'shared/fields/note', :locals => {:type => 'note'}.merge(component) %>
-<%= render :partial => 'shared/fields/note', :locals => {:type => 'related publications'}.merge(component) %>      
+<%= render :partial => 'shared/fields/note', :locals => {:type => 'related publications'}.merge(component) %>
 <%= render :partial => 'shared/fields/related_resource',
         :locals => {:collectionDoc => @document, :docType => 'object'}.merge(component) %>
 <%= render :partial => 'shared/fields/note', :locals => {:type => 'publication information'}.merge(component) %>
@@ -92,6 +92,7 @@
 <% end %>
 
 <%= render :partial => 'shared/fields/rights_holder', :locals => component %>
+<%= render :partial => 'shared/fields/last_modified' %>
 
 
 

--- a/spec/features/collections_search_spec.rb
+++ b/spec/features/collections_search_spec.rb
@@ -9,25 +9,25 @@ feature 'Visitor wants to browse by unit collections' do
       solr_index @unit.pid
       solr_index @oldest_collection.pid
 
-      Timecop.freeze(Date.today + 5) do
-        @newest_collection = DamsProvenanceCollection.create(pid:'collection_2', titleValue: "The New Collection", unitURI: @unit.pid, visibility: "public", resource_type: "text")
-        @newest_collection.damsMetadata.content = File.new('spec/fixtures/damsProvenanceCollection3.rdf.xml').read
-        solr_index @newest_collection.pid
-      end
+      # manipulate ActiveFedora::Base#create_date to create a "newer" collection record
+      allow_any_instance_of(DamsProvenanceCollection).to receive(:create_date).and_return(Time.now + 1.week)
+      @newest_collection = DamsProvenanceCollection.create(pid:'collection_2', titleValue: "The New Collection", unitURI: @unit.pid, visibility: "public", resource_type: "text")
+      @newest_collection.damsMetadata.content = File.new('spec/fixtures/damsProvenanceCollection3.rdf.xml').read
+      solr_index @newest_collection.pid
     end
     after do
       @unit.delete
       @oldest_collection.delete
       @newest_collection.delete
     end
-    xit 'should sort by most recent collection by default, descending to oldest' do
+    it 'should sort by most recent collection by default, descending to oldest' do
       visit dams_unit_collections_path('rdcp')
       old_collection_sort_order = page.body.index('A Old Collection')
       new_collection_sort_order = page.body.index('The New Collection')
       expect(old_collection_sort_order).to be > new_collection_sort_order
     end
 
-    xit 'should still allow user selected sort options' do
+    it 'should still allow user selected sort options' do
       visit dams_unit_collections_path('rdcp', { sort: 'title_ssi asc' })
       old_collection_sort_order = page.body.index('A Old Collection')
       new_collection_sort_order = page.body.index('The New Collection')

--- a/spec/features/dams_collections_spec.rb
+++ b/spec/features/dams_collections_spec.rb
@@ -118,6 +118,11 @@ feature 'Visitor wants to see the collection record' do
     @commonName.delete
   end
 
+  scenario 'should not see a last modified metadata entry' do
+    visit dams_collections_path("#{@provCollection.pid}")
+    expect(page).to_not have_selector('dt', text: 'Last Modified')
+  end
+
   scenario 'should see the related resource with no URI' do
     visit dams_collection_path("#{@provCollection.pid}")
     expect(page).to have_content('The physical materials are held at UC San Diego Library')
@@ -182,7 +187,7 @@ feature 'COLLECTIONS IMAGES --' do
     expect(page).to have_selector("#collections-image img")
     expect(find("#collections-image img")['alt']).to eq('Heavy Metals in the Ocean Insect, Halobates')
   end
-  
+
   scenario 'page should have collection image title attribute' do
     visit dams_collection_path("#{@provCollection.pid}")
     expect(find("#collections-image img")['title']).to eq('Heavy Metals in the Ocean Insect, Halobates')

--- a/spec/features/dams_object_spec.rb
+++ b/spec/features/dams_object_spec.rb
@@ -274,6 +274,10 @@ feature 'Visitor want to look at objects' do
       expect(page).to have_selector('li', text: 'Test Anatomy')
       expect(page).to have_selector('li', text: 'Test Value Anatomy')
 
+      # Last Modified
+      expect(page).to have_selector('dt', text: 'Last Modified')
+      expect(page).to have_selector('p', text: Time.now.strftime("%Y-%m-%d"))
+
       #Subject Label
       expect(page).to_not have_selector('dt', text: 'Lithologies')
       expect(page).to have_selector('dt', text: 'Lithology')


### PR DESCRIPTION
~~**WIP: please don't merge until @lsitu and I have been able to test this out w/ stakeholders in QA. This PR is up as an FYI for now.**~~

Fixes #643 
Fixes #644 

> Note: These are grouped into a single PR (separate commits) because they both depend on a new implementation of created and modified dates as discussed in https://github.com/ucsdlib/damsrepo/issues/92

#### Local Checklist
- [x] Tests written and passing locally?
- [x] Code style checked?
- [x] QA-ed locally?
- [x] Rebased with `master` branch?
- [ ] Configuration updated (if needed)?
- [ ] Documentation updated (if needed)?

#### What does this PR do?
- Sorts by created date for RDCP collections by default
- Adds a Last Modified Date to the DAMS Object view (only)

##### Why are we doing this? Any context of related work?
References #643 #644

#### Screenshots
Last Modified date on Object view:

![pic-selected-190710-1258-37](https://user-images.githubusercontent.com/67506/61000718-e6e4bd80-a312-11e9-88a5-e390d17937dd.png)

@ucsdlib/developers - please review
