### PR TITLE
Normalize dl buttons

### DIFF
--- a/app/assets/stylesheets/custom-object-viewer.css.scss
+++ b/app/assets/stylesheets/custom-object-viewer.css.scss
@@ -67,7 +67,6 @@ $complexFile: #AC6F2B !default;
 .dams-download-button{margin:0;}
 .dams-download-button p{margin: 0;text-align: center;}
 .dams-download-button .btn-mini{margin-top:5px;}
-#data-download-file{color:$componentHighlight;}
 
 // Breadcrumbs
 .dams-breadcrumbs .breadcrumb{font-size: 12px;background-color:transparent;padding: 0;}

--- a/app/views/dams_objects/_admin_download.html.erb
+++ b/app/views/dams_objects/_admin_download.html.erb
@@ -3,7 +3,7 @@
 	embed_url = (defined?(embedURL)) ? "#{embedURL}" : nil
 	etc_menu_item_class = 'pull-right'
 	embed_glyph =  '<i class="glyphicon glyphicon-share-alt"></i> Embed'.html_safe
-	adl_glyph =  '<i class="glyphicon glyphicon-download-alt"></i> Download File'.html_safe
+	adl_glyph =  '<i class="glyphicon glyphicon-download-alt"></i> Download file'.html_safe
   file_format = (defined?(format)) ? "#{format.capitalize}" : ''
   embed_width = (format == 'audio') ? '629' : '560'
   embed_height = (format == 'audio') ? '46' : '315'
@@ -22,12 +22,12 @@
     <%= link_to embed_glyph, "#embedLink-#{component_id}", class:etc_menu_item_class, role:'button', :data => { :toggle => 'modal' }, title:'Embed' %>
 
     <% if can? :update, @document then %>
-      <%= link_to adl_glyph, downloadFilePath, :rel => 'nofollow', class:etc_menu_item_class, title:'Download File' %>
+      <%= link_to adl_glyph, downloadFilePath, :rel => 'nofollow', class:etc_menu_item_class, title:'Download file' %>
     <% elsif can?(:read, @document) && can_download?(@document) && !downloadDerivativePath.nil?%>
-      <%= link_to adl_glyph, downloadDerivativePath, :rel => 'nofollow', class:etc_menu_item_class, title:'Download File' %>
+      <%= link_to adl_glyph, downloadDerivativePath, :rel => 'nofollow', class:etc_menu_item_class, title:'Download file' %>
     <% end %>
  </div>
-  
+
   <!-- BEGIN_EMBED_MODAL -->
   <div id="embedLink-<%=component_id%>" class="modal hide fade" tabindex="-1" role="dialog" aria-labelledby="embedLinkLabel" aria-hidden="true">
     <div class="modal-header">

--- a/app/views/dams_objects/_data_viewer.html.erb
+++ b/app/views/dams_objects/_data_viewer.html.erb
@@ -1,31 +1,32 @@
 <% if defined?(filePath) %>
 
-	<%
-	  btnColor = ''
-		if defined?(objectType)
-			btnColor = case objectType
-				when 'simple' then 'btn-primary'
-				when 'complex' then 'btn-inverse'
-			end
-		end
+  <%
+    btnColor = ''
+    if defined?(objectType)
+      btnColor = case objectType
+        when 'simple' then 'btn-primary'
+        when 'complex' then 'btn-inverse'
+      end
+    end
 
-		 viewFilePath = filePath.gsub('/download', '')
-	%>
+     viewFilePath = filePath.gsub('/download', '')
+  %>
 
-	
-		<% if !vrr_user? %>
-			<div class="form-actions dams-download-button">
-	    	<% if can?(:edit, @document) || can?(:read, @document) && can_download?(@document)%>
-			    <a id="data-view-file" class="btn <%=btnColor%> pull-right" href="<%= viewFilePath %>"><i class="glyphicon glyphicon-eye-open icon-white"></i> View file</a>
-			    <a id="data-download-file" class="btn btn-link pull-left btn-mini hidden-phone" href="<%= filePath %>" rel="nofollow"><i class="glyphicon glyphicon-download-alt"></i> Download file</a>
-			    <a id="data-download-file-phone" class="btn pull-left btn-mini visible-phone" href="<%= filePath %>" rel="nofollow"><i class="glyphicon glyphicon-download-alt"></i> Download file</a>
-	    	<% end %>
-	   	  <% if can? :update, @document%>
-		    	<% if (defined?(sourcefilePath) && !sourcefilePath.nil? && sourcefilePath != filePath)%>
-		      <a class="btn btn-link pull-left btn-mini hidden-phone" href="<%= sourcefilePath %>" rel="nofollow"><i class="glyphicon glyphicon-download-alt"></i> Download <%= File.extname(sourcefilePath.gsub('/download','')).upcase.gsub('.','')%> source</a>
-		      <a class="btn pull-left btn-mini visible-phone" href="<%= sourcefilePath %>" rel="nofollow"><i class="glyphicon glyphicon-download-alt"></i> Download <%= File.extname(sourcefilePath.gsub('/download','')).upcase.gsub('.','')%> source</a>
-		    	<% end %>
-		  	<% end %>
-			</div>
-		<% end %>
-	<% end %>
+    <% if !vrr_user? %>
+      <div class="form-actions dams-download-button">
+        <% if can?(:edit, @document) || can?(:read, @document) && can_download?(@document)%>
+          <div class="pull-right">
+            <a id="data-download-file" class="btn <%=btnColor%> hidden-phone" href="<%= filePath %>" rel="nofollow"><i class="glyphicon glyphicon-download-alt icon-white"></i> Download file</a>
+            <a id="data-view-file" class="btn <%=btnColor%>" href="<%= viewFilePath %>"><i class="glyphicon glyphicon-eye-open icon-white"></i> View file</a>
+            <a id="data-download-file-phone" class="btn <%=btnColor%> visible-phone" href="<%= filePath %>" rel="nofollow"><i class="glyphicon glyphicon-download-alt icon-white"></i> Download file</a>
+          </div>
+        <% end %>
+        <% if can? :update, @document%>
+          <% if (defined?(sourcefilePath) && !sourcefilePath.nil? && sourcefilePath != filePath)%>
+          <a class="btn btn-link pull-left btn-mini hidden-phone" href="<%= sourcefilePath %>" rel="nofollow"><i class="glyphicon glyphicon-download-alt"></i> Download <%= File.extname(sourcefilePath.gsub('/download','')).upcase.gsub('.','')%> source</a>
+          <a class="btn pull-left btn-mini visible-phone" href="<%= sourcefilePath %>" rel="nofollow"><i class="glyphicon glyphicon-download-alt"></i> Download <%= File.extname(sourcefilePath.gsub('/download','')).upcase.gsub('.','')%> source</a>
+          <% end %>
+        <% end %>
+      </div>
+    <% end %>
+  <% end %>

--- a/spec/features/dams_object_spec.rb
+++ b/spec/features/dams_object_spec.rb
@@ -1722,7 +1722,7 @@ describe "View an object that has no DOI identifier" do
   end
 end
 
-describe "vrr user who has authorized works should not see Download File and Embed button" do
+describe "vrr user who has authorized works should not see Download file and Embed button" do
   let!(:user) { create_auth_link_user }
 
   before(:all) do
@@ -1747,13 +1747,13 @@ describe "vrr user who has authorized works should not see Download File and Emb
     @pdfObj.delete
   end
 
-  scenario "the admin_download viewer should not show Download File and Embed button" do
+  scenario "the admin_download viewer should not show Download file and Embed button" do
     user.work_authorizations.create(work_title: 'vrr_test', work_pid: @imgObj.pid)
 
     visit new_user_session_path(email: user.email, auth_token: user.authentication_token)
     click_link "View"
 
-    expect(page).not_to have_text("Download File")
+    expect(page).not_to have_text("Download file")
     expect(page).not_to have_text("Embed")
   end
 

--- a/spec/features/file_spec.rb
+++ b/spec/features/file_spec.rb
@@ -2,7 +2,7 @@ require 'spec_helper'
 require 'cancan'
 
 
-feature "Derivative download" do 
+feature "Derivative download" do
   before(:all) do
     @unit = DamsUnit.create pid: 'xx48484848', name: "Test Unit", description: "Test Description",
                 code: "tu", uri: "http://example.com/"
@@ -77,8 +77,8 @@ feature "Derivative download" do
   scenario 'should have rel=nofollow for the download link' do
     sign_in_developer
     visit dams_object_path @obj2
-    expect(page).to have_css('a[title="Download File"][rel="nofollow"]')
-  end    
+    expect(page).to have_css('a[title="Download file"][rel="nofollow"]')
+  end
 end
 
 describe "Download more than one master file" do
@@ -88,7 +88,7 @@ describe "Download more than one master file" do
     @newspaper = DamsObject.create(pid: "xx21171293")
     @newspaper.damsMetadata.content = File.new('spec/fixtures/damsObjectNewspaper.rdf.xml').read
     @newspaper.save!
-    solr_index (@newspaper.pid)   
+    solr_index (@newspaper.pid)
   end
   after do
     @newspaper.delete
@@ -97,11 +97,11 @@ describe "Download more than one master file" do
     visit dams_object_path(@newspaper.pid)
     expect(page).to have_link('', href:"/object/xx21171293/_1.pdf/download")
     expect(page).to_not have_link('', href:"/object/xx21171293/_2.tgz/download")
-    
+
     sign_in_developer
     visit dams_object_path(@newspaper.pid)
     expect(page).to have_link('', href:"/object/xx21171293/_1.pdf/download?access=curator")
-    expect(page).to have_link('', href:"/object/xx21171293/_2.tgz/download?access=curator")    
+    expect(page).to have_link('', href:"/object/xx21171293/_2.tgz/download?access=curator")
   end
 end
 
@@ -122,7 +122,7 @@ describe "Download file in complex object" do
   it "should show a download button" do
     sign_in_developer
     visit dams_object_path @complexObj.pid
-    expect(page).to have_link('', href:"/object/#{@complexObj.pid}/_1_2.jpg/download?access=curator")  
+    expect(page).to have_link('', href:"/object/#{@complexObj.pid}/_1_2.jpg/download?access=curator")
   end
 end
 
@@ -145,6 +145,6 @@ describe "Download PDF file and second file with use value ends with '-source' f
     sign_in_developer
     visit dams_object_path @complexObjPdf.pid
     expect(page).to have_link('', href:"/object/#{@complexObjPdf.pid}/_1_1.pdf/download?access=curator")
-    expect(page).to have_link('', href:"/object/#{@complexObjPdf.pid}/_1_2.mov/download?access=curator")    
+    expect(page).to have_link('', href:"/object/#{@complexObjPdf.pid}/_1_2.mov/download?access=curator")
   end
 end


### PR DESCRIPTION
Fixes #638 

#### Local Checklist
- [ ] Tests written and passing locally?
- [ ] Code style checked?
- [ ] QA-ed locally?
- [ ] Rebased with `master` branch?
- [ ] Configuration updated (if needed)?
- [ ] Documentation updated (if needed)?

#### What does this PR do?
- Normalized the download button text to `Download file`
- For data viewer, make download button the same size as the view file button, and align(pull) right

##### Why are we doing this? Any context of related work?
References #638  - RDCP would like the download feature to be more prominent than was previously designed for.

##### Screenshots
![image](https://user-images.githubusercontent.com/67506/61245428-54249400-a701-11e9-9a63-69b35be9bb6b.png)


@ucsdlib/developers - please review
