### PR TITLE
Title sorting ignores quotes and case

### DIFF
--- a/solr_config/config/schema.xml
+++ b/solr_config/config/schema.xml
@@ -3,14 +3,14 @@
   <!-- NOTE: various comments and unused configuration possibilities have been purged
      from this file.  Please refer to http://wiki.apache.org/solr/SchemaXml,
      as well as the default schema file included with Solr -->
-  
+
   <uniqueKey>id</uniqueKey>
-  
+
   <fields>
     <field name="id" type="string" stored="true" indexed="true" multiValued="false" required="true"/>
     <field name="id_t" type="string" stored="true" indexed="true" multiValued="false" required="true"/>
     <field name="timestamp" type="date" indexed="true" stored="true" default="NOW" multiValued="false"/>
-    
+
     <field name="lat" type="tdouble" stored="true" indexed="true" multiValued="false"/>
     <field name="lng" type="tdouble" stored="true" indexed="true" multiValued="false"/>
 
@@ -26,9 +26,12 @@
     <!-- explicit rdfxml field (could be large)-->
     <field name="rdfxml_ssi" type="text_en" stored="true" indexed="false" multiValued="false"/>
 
+    <!-- explicitly declare/override title_ssi, because we have custom sorting requirements -->
+    <field name="title_ssi" type="alphaStrippedSort" stored="true" indexed="true" multiValued="false"/>
+
 	<!--
 	These are hard coded in places in hydra-head, but we hope to fix that.
-	
+
 	<field name="inheritable_discover_access_person_t" type="string" stored="true" indexed="true" multiValued="true"/>
 	<field name="inheritable_read_access_person_t" type="string" stored="true" indexed="true" multiValued="true"/>
 	<field name="inheritable_edit_access_person_t" type="string" stored="true" indexed="true" multiValued="true"/>
@@ -41,7 +44,7 @@
 	<field name="read_access_group_t" type="string" stored="true" indexed="true" multiValued="true"/>
 	<field name="edit_access_group_t" type="string" stored="true" indexed="true" multiValued="true"/>
 	<field name="discover_access_group_t" type="string" stored="true" indexed="true" multiValued="true"/>
-	-->	
+	-->
 
 
     <!-- NOTE:  not all possible Solr field types are represented in the dynamic fields -->
@@ -57,7 +60,7 @@
     <dynamicField name="*_timv" type="text" stored="false" indexed="true" multiValued="true" termVectors="true" termPositions="true" termOffsets="true"/>
     <dynamicField name="*_tsiv" type="text" stored="true" indexed="true" multiValued="false" termVectors="true" termPositions="true" termOffsets="true"/>
     <dynamicField name="*_tsimv" type="text" stored="true" indexed="true" multiValued="true" termVectors="true" termPositions="true" termOffsets="true"/>
-    
+
     <!-- English text (_te...) -->
     <dynamicField name="*_tei" type="text_en" stored="false" indexed="true" multiValued="false"/>
     <dynamicField name="*_teim" type="text_en" stored="false" indexed="true" multiValued="true"/>
@@ -69,7 +72,7 @@
     <dynamicField name="*_teimv" type="text_en" stored="false" indexed="true" multiValued="true" termVectors="true" termPositions="true" termOffsets="true"/>
     <dynamicField name="*_tesiv" type="text_en" stored="true" indexed="true" multiValued="false" termVectors="true" termPositions="true" termOffsets="true"/>
     <dynamicField name="*_tesimv" type="text_en" stored="true" indexed="true" multiValued="true" termVectors="true" termPositions="true" termOffsets="true"/>
-    
+
     <!-- string (_s...) -->
     <dynamicField name="*_si" type="string" stored="false" indexed="true" multiValued="false"/>
     <dynamicField name="*_sim" type="string" stored="false" indexed="true" multiValued="true"/>
@@ -78,7 +81,7 @@
     <dynamicField name="*_ssi" type="string" stored="true" indexed="true" multiValued="false"/>
     <dynamicField name="*_ssim" type="string" stored="true" indexed="true" multiValued="true"/>
     <dynamicField name="*_ssort" type="alphaSort" stored="false" indexed="true" multiValued="false"/>
-    
+
     <!-- integer (_i...) -->
     <dynamicField name="*_ii" type="int" stored="false" indexed="true" multiValued="false"/>
     <dynamicField name="*_iim" type="int" stored="false" indexed="true" multiValued="true"/>
@@ -86,7 +89,7 @@
     <dynamicField name="*_ism" type="int" stored="true" indexed="false" multiValued="true"/>
     <dynamicField name="*_isi" type="int" stored="true" indexed="true" multiValued="false"/>
     <dynamicField name="*_isim" type="int" stored="true" indexed="true" multiValued="true"/>
-    
+
     <!-- trie integer (_it...) (for faster range queries) -->
     <dynamicField name="*_iti" type="tint" stored="false" indexed="true" multiValued="false"/>
     <dynamicField name="*_itim" type="tint" stored="false" indexed="true" multiValued="true"/>
@@ -94,7 +97,7 @@
     <dynamicField name="*_itsm" type="tint" stored="true" indexed="false" multiValued="true"/>
     <dynamicField name="*_itsi" type="tint" stored="true" indexed="true" multiValued="false"/>
     <dynamicField name="*_itsim" type="tint" stored="true" indexed="true" multiValued="true"/>
-    
+
     <!-- date (_dt...) -->
     <!-- The format for this date field is of the form 1995-12-31T23:59:59Z
          Optional fractional seconds are allowed: 1995-12-31T23:59:59.999Z -->
@@ -104,7 +107,7 @@
     <dynamicField name="*_dtsm" type="date" stored="true" indexed="false" multiValued="true"/>
     <dynamicField name="*_dtsi" type="date" stored="true" indexed="true" multiValued="false"/>
     <dynamicField name="*_dtsim" type="date" stored="true" indexed="true" multiValued="true"/>
-    
+
     <!-- trie date (_dtt...) (for faster range queries) -->
     <dynamicField name="*_dtti" type="tdate" stored="false" indexed="true" multiValued="false"/>
     <dynamicField name="*_dttim" type="tdate" stored="false" indexed="true" multiValued="true"/>
@@ -112,7 +115,7 @@
     <dynamicField name="*_dttsm" type="tdate" stored="true" indexed="false" multiValued="true"/>
     <dynamicField name="*_dttsi" type="tdate" stored="true" indexed="true" multiValued="false"/>
     <dynamicField name="*_dttsim" type="tdate" stored="true" indexed="true" multiValued="true"/>
-    
+
     <!-- long (_l...) -->
     <dynamicField name="*_li" type="long" stored="false" indexed="true" multiValued="false"/>
     <dynamicField name="*_lim" type="long" stored="false" indexed="true" multiValued="true"/>
@@ -120,7 +123,7 @@
     <dynamicField name="*_lsm" type="long" stored="true" indexed="false" multiValued="true"/>
     <dynamicField name="*_lsi" type="long" stored="true" indexed="true" multiValued="false"/>
     <dynamicField name="*_lsim" type="long" stored="true" indexed="true" multiValued="true"/>
-    
+
     <!-- trie long (_lt...) (for faster range queries) -->
     <dynamicField name="*_lti" type="tlong" stored="false" indexed="true" multiValued="false"/>
     <dynamicField name="*_ltim" type="tlong" stored="false" indexed="true" multiValued="true"/>
@@ -128,7 +131,7 @@
     <dynamicField name="*_ltsm" type="tlong" stored="true" indexed="false" multiValued="true"/>
     <dynamicField name="*_ltsi" type="tlong" stored="true" indexed="true" multiValued="false"/>
     <dynamicField name="*_ltsim" type="tlong" stored="true" indexed="true" multiValued="true"/>
-    
+
     <!-- double (_db...) -->
     <dynamicField name="*_dbi" type="double" stored="false" indexed="true" multiValued="false"/>
     <dynamicField name="*_dbim" type="double" stored="false" indexed="true" multiValued="true"/>
@@ -136,7 +139,7 @@
     <dynamicField name="*_dbsm" type="double" stored="true" indexed="false" multiValued="true"/>
     <dynamicField name="*_dbsi" type="double" stored="true" indexed="true" multiValued="false"/>
     <dynamicField name="*_dbsim" type="double" stored="true" indexed="true" multiValued="true"/>
-    
+
     <!-- trie double (_dbt...) (for faster range queries) -->
     <dynamicField name="*_dbti" type="tdouble" stored="false" indexed="true" multiValued="false"/>
     <dynamicField name="*_dbtim" type="tdouble" stored="false" indexed="true" multiValued="true"/>
@@ -144,7 +147,7 @@
     <dynamicField name="*_dbtsm" type="tdouble" stored="true" indexed="false" multiValued="true"/>
     <dynamicField name="*_dbtsi" type="tdouble" stored="true" indexed="true" multiValued="false"/>
     <dynamicField name="*_dbtsim" type="tdouble" stored="true" indexed="true" multiValued="true"/>
-    
+
     <!-- float (_f...) -->
     <dynamicField name="*_fi" type="float" stored="false" indexed="true" multiValued="false"/>
     <dynamicField name="*_fim" type="float" stored="false" indexed="true" multiValued="true"/>
@@ -152,7 +155,7 @@
     <dynamicField name="*_fsm" type="float" stored="true" indexed="false" multiValued="true"/>
     <dynamicField name="*_fsi" type="float" stored="true" indexed="true" multiValued="false"/>
     <dynamicField name="*_fsim" type="float" stored="true" indexed="true" multiValued="true"/>
-    
+
     <!-- trie float (_ft...) (for faster range queries) -->
     <dynamicField name="*_fti" type="tfloat" stored="false" indexed="true" multiValued="false"/>
     <dynamicField name="*_ftim" type="tfloat" stored="false" indexed="true" multiValued="true"/>
@@ -160,12 +163,12 @@
     <dynamicField name="*_ftsm" type="tfloat" stored="true" indexed="false" multiValued="true"/>
     <dynamicField name="*_ftsi" type="tfloat" stored="true" indexed="true" multiValued="false"/>
     <dynamicField name="*_ftsim" type="tfloat" stored="true" indexed="true" multiValued="true"/>
-    
+
     <!-- boolean (_b...) -->
     <dynamicField name="*_bi" type="boolean" stored="false" indexed="true" multiValued="false"/>
     <dynamicField name="*_bs" type="boolean" stored="true" indexed="false" multiValued="false"/>
     <dynamicField name="*_bsi" type="boolean" stored="true" indexed="true" multiValued="false"/>
-    
+
     <!-- Type used to index the lat and lon components for the "location" FieldType -->
     <dynamicField name="*_coordinate" type="tdouble" indexed="true"  stored="false" />
 
@@ -181,7 +184,7 @@
     <field name="all_text_timv" type="text" stored="false" indexed="true" multiValued="true" termVectors="true" termPositions="true" termOffsets="true"/>
 
     <!-- deprecated fields from pre-Solr 4.0 pre-hydra 5.0 -->
-<!--    
+<!--
     <field name="marc_display" type="string" indexed="false" stored="true" multiValued="false"/>
     <field name="title_display" type="string" indexed="false" stored="true" multiValued="false"/>
     <field name="title_vern_display" type="string" indexed="false" stored="true" multiValued="false"/>
@@ -191,7 +194,7 @@
     <field name="author_vern_display" type="string" indexed="false" stored="true" multiValued="false"/>
 -->
     <!-- these fields are also used for display, so they must be stored -->
-<!--    
+<!--
     <field name="isbn_t" type="text" indexed="true" stored="true" multiValued="true"/>
     <field name="language_facet" type="string" indexed="true" stored="true" multiValued="true" />
     <field name="subject_topic_facet" type="string" indexed="true" stored="true" multiValued="true" />
@@ -199,16 +202,16 @@
     <field name="subject_geo_facet" type="string" indexed="true" stored="true" multiValued="true" />
 -->
      <!-- pub_date is used for facet and display so it must be indexed and stored -->
-<!--    
+<!--
     <field name="pub_date" type="string" indexed="true" stored="true" multiValued="true"/>
 -->
     <!-- pub_date sort uses new trie-based int fields, which are recommended for any int and are displayable, sortable, and range-quer
     we use 'tint' for faster range-queries. -->
-<!--    
+<!--
     <field name="pub_date_sort" type="tint" indexed="true" stored="true" multiValued="false"/>
 -->
     <!-- format is used for facet, display, and choosing which partial to use for the show view, so it must be stored and indexed -->
-<!--    
+<!--
     <field name="format" type="string" indexed="true" stored="true"/>
 
     <dynamicField name="*_i"  type="int"    indexed="true"  stored="true"/>
@@ -243,11 +246,11 @@
   </fields>
 
   <!-- START hydra deprecated items -->
-<!--  
+<!--
   <defaultSearchField>text</defaultSearchField>
 -->
   <!-- SolrQueryParser configuration: defaultOperator="AND|OR" -->
-<!--  
+<!--
   <solrQueryParser defaultOperator="AND"/>
 
   <copyField source="title_t" dest="title_unstem_search"/>
@@ -262,7 +265,7 @@
   <copyField source="subject_topic_facet" dest="subject_topic_unstem_search"/>
 -->
   <!-- sort fields -->
-<!--  
+<!--
   <copyField source="pub_date" dest="pub_date_sort"/>
 -->
 
@@ -272,12 +275,12 @@
   <!-- spellcheck fields -->
   <!-- default spell check;  should match fields for default request handler -->
   <!-- it won't work with a copy of a copy field -->
-<!-- 
+<!--
   <copyField source="*_t" dest="spell"/>
   <copyField source="*_facet" dest="spell"/>
 -->
   <!-- title spell check;  should match fields for title request handler -->
-<!-- 
+<!--
   <copyField source="title_t" dest="title_spell"/>
   <copyField source="subtitle_t" dest="title_spell"/>
   <copyField source="addl_titles_t" dest="title_spell"/>
@@ -285,19 +288,19 @@
   <copyField source="title_series_t" dest="title_spell"/>
 -->
   <!-- author spell check; should match fields for author request handler -->
-<!-- 
+<!--
   <copyField source="author_t" dest="author_spell"/>
   <copyField source="author_addl_t" dest="author_spell"/>
 -->
   <!-- subject spell check; should match fields for subject request handler -->
-<!-- 
+<!--
   <copyField source="subject_topic_facet" dest="subject_spell"/>
   <copyField source="subject_t" dest="subject_spell"/>
   <copyField source="subject_addl_t" dest="subject_spell"/>
 -->
-  
+
   <!-- OpenSearch query field should match request handler search fields -->
-<!--  
+<!--
   <copyField source="title_t" dest="opensearch_display"/>
   <copyField source="subtitle_t" dest="opensearch_display"/>
   <copyField source="addl_titles_t" dest="opensearch_display"/>
@@ -316,7 +319,7 @@
       copyField also supports a maxChars to copy setting.  -->
 
     <!-- <copyField source="*_t" dest="text" maxChars="3000"/> -->
-<!--  
+<!--
     <copyField source="*_s" dest="text"/>
     <copyField source="*_t" dest="text"/>
     <copyField source="*_facet" dest="text"/>
@@ -329,36 +332,36 @@
   <!-- copy fields;  note that you must define copyField source and dest fields explicity or schemaBrowser doesn't work -->
 <!--
   <copyField source="some_field" dest="all_text_timv" />
--->  
+-->
 
   <types>
     <fieldType name="string" class="solr.StrField" sortMissingLast="true" />
-    <fieldType name="boolean" class="solr.BoolField" sortMissingLast="true"/>    
+    <fieldType name="boolean" class="solr.BoolField" sortMissingLast="true"/>
     <fieldType name="rand" class="solr.RandomSortField" omitNorms="true"/>
-    
+
     <!-- Default numeric field types.  -->
     <fieldType name="int" class="solr.TrieIntField" precisionStep="0" positionIncrementGap="0"/>
     <fieldType name="float" class="solr.TrieFloatField" precisionStep="0" positionIncrementGap="0"/>
     <fieldType name="long" class="solr.TrieLongField" precisionStep="0" positionIncrementGap="0"/>
     <fieldType name="double" class="solr.TrieDoubleField" precisionStep="0" positionIncrementGap="0"/>
-    
+
     <!-- trie numeric field types for faster range queries -->
     <fieldType name="tint" class="solr.TrieIntField" precisionStep="8" positionIncrementGap="0"/>
     <fieldType name="tfloat" class="solr.TrieFloatField" precisionStep="8" positionIncrementGap="0"/>
     <fieldType name="tlong" class="solr.TrieLongField" precisionStep="8" positionIncrementGap="0"/>
     <fieldType name="tdouble" class="solr.TrieDoubleField" precisionStep="8" positionIncrementGap="0"/>
-    
+
     <!-- The format for this date field is of the form 1995-12-31T23:59:59Z
          Optional fractional seconds are allowed: 1995-12-31T23:59:59.999Z
       -->
     <fieldType name="date" class="solr.TrieDateField" precisionStep="0" positionIncrementGap="0"/>
     <!-- A Trie based date field for faster date range queries and date faceting. -->
     <fieldType name="tdate" class="solr.TrieDateField" precisionStep="6" positionIncrementGap="0"/>
-    
-    
+
+
     <!-- This point type indexes the coordinates as separate fields (subFields)
       If subFieldType is defined, it references a type, and a dynamic field
-      definition is created matching *___<typename>.  Alternately, if 
+      definition is created matching *___<typename>.  Alternately, if
       subFieldSuffix is defined, that is used to create the subFields.
       Example: if subFieldType="double", then the coordinates would be
         indexed in fields myloc_0___double,myloc_1___double.
@@ -368,17 +371,17 @@
       users normally should not need to know about them.
      -->
     <fieldType name="point" class="solr.PointType" dimension="2" subFieldSuffix="_d"/>
-    
+
     <!-- A specialized field for geospatial search. If indexed, this fieldType must not be multivalued. -->
     <fieldType name="location" class="solr.LatLonType" subFieldSuffix="_coordinate"/>
-    
+
     <!-- An alternative geospatial field type new to Solr 4.  It supports multiValued and polygon shapes.
       For more information about this and other Spatial fields new to Solr 4, see:
       http://wiki.apache.org/solr/SolrAdaptersForLuceneSpatial4
     -->
     <fieldType name="location_rpt" class="solr.SpatialRecursivePrefixTreeFieldType"
       geo="true" distErrPct="0.025" maxDistErr="0.000009" units="degrees" />
-    
+
     <fieldType name="text" class="solr.TextField" omitNorms="false">
       <analyzer>
         <tokenizer class="solr.ICUTokenizerFactory"/>
@@ -386,7 +389,7 @@
         <filter class="solr.TrimFilterFactory"/>
       </analyzer>
     </fieldType>
-    
+
     <!-- A text field that only splits on whitespace for exact matching of words -->
     <fieldType name="text_ws" class="solr.TextField" positionIncrementGap="100">
       <analyzer>
@@ -394,7 +397,18 @@
         <filter class="solr.TrimFilterFactory"/>
       </analyzer>
     </fieldType>
-        
+
+    <!-- single token analyzed text, for sorting.  Punctuation is significant. -->
+    <fieldtype name="alphaStrippedSort" class="solr.TextField" sortMissingLast="true" omitNorms="true">
+      <analyzer>
+        <charFilter class="solr.PatternReplaceCharFilterFactory" pattern="[;:\'&quot;\(\)]"/>
+        <tokenizer class="solr.KeywordTokenizerFactory" />
+        <filter class="solr.LowerCaseFilterFactory"/>
+        <filter class="solr.ICUFoldingFilterFactory"/>
+        <filter class="solr.TrimFilterFactory" />
+      </analyzer>
+    </fieldtype>
+
     <!-- single token analyzed text, for sorting.  Punctuation is significant. -->
     <fieldtype name="alphaSort" class="solr.TextField" sortMissingLast="true" omitNorms="true">
       <analyzer>
@@ -411,7 +425,7 @@
 	<filter class="solr.StopFilterFactory" ignoreCase="true" words="stopwords.txt"/>
         <filter class="solr.TrimFilterFactory"/>
         <filter class="solr.SnowballPorterFilterFactory" language="English"/>
-      </analyzer> 
+      </analyzer>
     </fieldType>
 
     <!-- A text field with defaults appropriate for English -->
@@ -428,7 +442,7 @@
         <filter class="solr.TrimFilterFactory"/>
       </analyzer>
     </fieldType>
-        
+
     <!-- queries for paths match documents at that path, or in descendent paths -->
     <fieldType name="descendent_path" class="solr.TextField">
       <analyzer type="index">
@@ -438,7 +452,7 @@
         <tokenizer class="solr.KeywordTokenizerFactory" />
       </analyzer>
     </fieldType>
-    
+
     <!-- queries for paths match documents at that path, or in ancestor paths -->
     <fieldType name="ancestor_path" class="solr.TextField">
       <analyzer type="index">
@@ -450,5 +464,5 @@
     </fieldType>
 
   </types>
-  
+
 </schema>

--- a/spec/features/catalog_spec.rb
+++ b/spec/features/catalog_spec.rb
@@ -12,11 +12,11 @@ feature 'Visitor wants to search' do
     @obj1 = DamsObject.create titleValue: "QE8iWjhafTRpc Object 1", unitURI: @unit.pid, copyrightURI: @copy.pid, date_attributes: [{type: 'creation', beginDate: '2000-05-10', endDate: '2050-05-11', value: '2000-05-10 to 2050-05-11'}], topic_attributes: [{ id: RDF::URI.new("#{ns}#{@topic1.pid}") }]
     @obj2 = DamsObject.create titleValue: "QE8iWjhafTRpc Object 2", unitURI: @unit.pid, copyrightURI: @copy.pid, date_attributes: [{type: 'creation', beginDate: '1999', value: '1999'}], topic_attributes: [{ id: RDF::URI.new("#{ns}#{@topic2.pid}") }]
     @obj3 = DamsObject.create titleValue: "QE8iWjhafTRpc Object 3", unitURI: @unit.pid, copyrightURI: @copy.pid
-  
+
     solr_index @obj1.pid
     solr_index @obj2.pid
     solr_index @obj3.pid
-    
+
   end
   after(:all) do
     @obj1.delete
@@ -42,7 +42,7 @@ feature 'Visitor wants to search' do
   end
 
   scenario 'is on search results page' do
-    visit catalog_index_path( {:q => 'QE8iWjhafTRpc'} )    
+    visit catalog_index_path( {:q => 'QE8iWjhafTRpc'} )
     expect(page).to have_selector('h4', :text => 'Refine your search')
     expect(page).to have_selector('h3', :text => 'QE8iWjhafTRpc Object 1')
     expect(page).to have_selector('h3', :text => 'QE8iWjhafTRpc Object 2')
@@ -70,21 +70,21 @@ feature 'Visitor wants to search' do
   scenario 'Search with single or double quotes' do
     visit catalog_index_path( {:q => 'QE8iWjhafTRpc'} )
     expect(page).to have_selector('h3', :text => 'QE8iWjhafTRpc Object 1')
-    
+
     visit catalog_index_path( {:q => '"QE8iWjhafTRpc'} )
     expect(page).to have_selector('h3', :text => 'QE8iWjhafTRpc Object 1')
-    
+
     visit catalog_index_path( {:q => 'QE8iWjhafTRpc"'} )
-    expect(page).to have_selector('h3', :text => 'QE8iWjhafTRpc Object 1')    
+    expect(page).to have_selector('h3', :text => 'QE8iWjhafTRpc Object 1')
 
     visit catalog_index_path( {:q => 'QE8iWjhafTRpc""'} )
-    expect(page).to have_selector('h3', :text => 'QE8iWjhafTRpc Object 1')    
-    
+    expect(page).to have_selector('h3', :text => 'QE8iWjhafTRpc Object 1')
+
     visit catalog_index_path( {:q => '""QE8iWjhafTRpc'} )
-    expect(page).to have_selector('h3', :text => 'QE8iWjhafTRpc Object 1')   
-    
+    expect(page).to have_selector('h3', :text => 'QE8iWjhafTRpc Object 1')
+
     visit catalog_index_path( {:q => '"QE8iWjhafTRpc"'} )
-    expect(page).to have_selector('h3', :text => 'QE8iWjhafTRpc Object 1') 
+    expect(page).to have_selector('h3', :text => 'QE8iWjhafTRpc Object 1')
   end
 
   scenario 'results sorted by object creation date should work for both single date and range date' do
@@ -110,19 +110,19 @@ feature 'Visitor wants to search' do
 
   scenario 'Browse by Topic page' do
     visit catalog_facet_path("subject_topic_sim", :'facet.sort' => 'index', :'facet.prefix' => 'Z')
-    
+
     expect(page).to have_selector('.btn', :text => 'Z')
     idx1 = page.body.index('ZZZ Test Subject 1')
     idx2 = page.body.index('ZZZ Test Subject 2')
     expect(idx2).to be >( idx1 )
-    
+
     click_on("Sort 1-9", match: :first)
     expect(page).to have_link('A', href: '/search/facet/subject_topic_sim?facet.prefix=A&facet.sort=index' )
     expect(page).to have_selector('.btn', :text => 'Z')
     idx1 = page.body.index('ZZZ Test Subject 1')
     idx2 = page.body.index('ZZZ Test Subject 2')
     expect(idx1).to be <( idx2 )
-  end  
+  end
 
   scenario 'search results paging' do
     visit catalog_index_path( {'q' => 'QE8iWjhafTRpc', 'sort' => 'title_ssi asc'} )
@@ -152,15 +152,15 @@ feature 'Visitor wants to search' do
     expect(page).to have_xpath "//a[contains(@href,'?counter=1&access=curator')]"
     expect(page).to have_link('QE8iWjhafTRpc Object 1', href:"/object/#{@obj1.pid}?counter=1&access=curator")
   end
- 
+
   scenario 'decade faceting displays in chronological order ' do
     visit catalog_index_path( {'q' => 'QE8iWjhafTRpc'} )
     expect(page).to have_link('2000s', href: catalog_index_path({'f[decade_sim][]' => '2000s', 'q' => 'QE8iWjhafTRpc'}))
-    expect(page).to have_selector("div.blacklight-decade_sim ul li[1]", :text => '2050s 1') 
-    expect(page).to have_selector("div.blacklight-decade_sim ul li[2]", :text => '2040s 1') 
-    expect(page).to have_selector("div.blacklight-decade_sim ul li[3]", :text => '2030s 1') 
-    expect(page).to have_selector("div.blacklight-decade_sim ul li[4]", :text => '2020s 1') 
-    expect(page).to have_selector("div.blacklight-decade_sim ul li[5]", :text => '2010s 1')  
+    expect(page).to have_selector("div.blacklight-decade_sim ul li[1]", :text => '2050s 1')
+    expect(page).to have_selector("div.blacklight-decade_sim ul li[2]", :text => '2040s 1')
+    expect(page).to have_selector("div.blacklight-decade_sim ul li[3]", :text => '2030s 1')
+    expect(page).to have_selector("div.blacklight-decade_sim ul li[4]", :text => '2020s 1')
+    expect(page).to have_selector("div.blacklight-decade_sim ul li[5]", :text => '2010s 1')
     expect(page).to have_selector("div.blacklight-decade_sim ul li[6]", :text => '2000s 1')
     expect(page).to have_selector("div.blacklight-decade_sim ul li[7]", :text => '1990s 1')
   end
@@ -230,10 +230,10 @@ feature "Search and browse custom subject facet links" do
     @lithology = DamsLithology.create( name: 'ZZZ Test Lithology' )
     @science = DamsScientificName.create( name: 'ZZZ Test Scientific Name' )
     @series = DamsSeries.create( name: 'ZZZ Test Series' )
-    @obj = DamsObject.create( 
-        titleValue: 'QE8iWjhafTRpc Test Object', 
-        unitURI: @unit.pid, 
-        copyrightURI: @copy.pid, 
+    @obj = DamsObject.create(
+        titleValue: 'QE8iWjhafTRpc Test Object',
+        unitURI: @unit.pid,
+        copyrightURI: @copy.pid,
         anatomy_attributes: [{ id: RDF::URI.new("#{ns}#{@anatomy.pid}") }],
         commonName_attributes: [{ id: RDF::URI.new("#{ns}#{@common.pid}") }],
         cruise_attributes: [{ id: RDF::URI.new("#{ns}#{@cruise.pid}") }],
@@ -297,7 +297,7 @@ feature "Search and browse custom subject facet links" do
     expect(page).to have_content('ZZZ Test Lithology')
     click_on "ZZZ Test Lithology"
     expect(page).to have_content('QE8iWjhafTRpc Test Object')
-  end    
+  end
   scenario 'Browse by scientific name' do
     sign_in_developer
     visit catalog_facet_path("subject_scientific_name_sim", :'facet.sort' => 'index', :'facet.prefix' => 'Z')
@@ -314,8 +314,8 @@ feature "Search and browse custom subject facet links" do
   end
   scenario 'topic faceting displays exclude anatomy, cultureContext, series, lithology, common name, scientific name and cruise values' do
     visit catalog_index_path( {'q' => @obj.pid} )
-    expect(page).to have_selector("div.blacklight-subject_topic_sim ul li", :count => 0)     
-  end   
+    expect(page).to have_selector("div.blacklight-subject_topic_sim ul li", :count => 0)
+  end
 end
 
 describe "Search and browse custom subject facets from complex object" do
@@ -393,21 +393,21 @@ feature 'Visitor wants to see collection info in the search results view' do
   end
   scenario 'should see the results page with collection info' do
     visit catalog_index_path( {:q => 'sample'} )
-    expect(page).to have_selector('h3', :text => 'YQu9XjFgDT4UYA7WBQRsg Object')   
-    expect(page).to have_selector("span.dams-search-results-fields-label:first", :text => 'Collection:')     
+    expect(page).to have_selector('h3', :text => 'YQu9XjFgDT4UYA7WBQRsg Object')
+    expect(page).to have_selector("span.dams-search-results-fields-label:first", :text => 'Collection:')
   end
-  
+
   scenario 'should see the results page with multiple collection display' do
     visit catalog_index_path( {:q => 'YQu9XjFgDT4UYA7WBQRsg Object'} )
-    expect(page).to have_selector('h3', :text => 'YQu9XjFgDT4UYA7WBQRsg Object')   
+    expect(page).to have_selector('h3', :text => 'YQu9XjFgDT4UYA7WBQRsg Object')
     expect(page).to have_selector("span.dams-search-results-fields-label:first", :text => 'Collection:')
-    expect(page).to have_selector("ul.dams-search-results-fields:first li span[2]", :text => 'The Sample Assembled Collection: Subtitle, Allegro, 1')    
-    expect(page).to have_selector("ul.dams-search-results-fields:first li span[2]", :text => 'The Sample Provenance Part: Subtitle, Allegro, 1')    
+    expect(page).to have_selector("ul.dams-search-results-fields:first li span[2]", :text => 'The Sample Assembled Collection: Subtitle, Allegro, 1')
+    expect(page).to have_selector("ul.dams-search-results-fields:first li span[2]", :text => 'The Sample Provenance Part: Subtitle, Allegro, 1')
   end
-  
+
   scenario 'should see the collection info before other fields in single object viewer' do
     visit catalog_index_path( {:q => 'sample'} )
-    expect(page).to have_selector('h3', :text => 'YQu9XjFgDT4UYA7WBQRsg Object')   
+    expect(page).to have_selector('h3', :text => 'YQu9XjFgDT4UYA7WBQRsg Object')
     click_on "YQu9XjFgDT4UYA7WBQRsg Object"
     expect(page).to have_selector("dt:first", :text => 'Collection')
   end
@@ -466,6 +466,41 @@ feature 'User wants to see search results' do
   end
 end
 
+feature 'User wants sorted results by title' do
+  before(:all) do
+    @unit = DamsUnit.create(name: 'Test Unit', description: 'Test Description', code: 'tu', uri: 'http://example.com/', group: 'dams-curator')
+    @copy = DamsCopyright.create(status: 'Public domain')
+    @obj1 = DamsObject.create(titleValue: 'aunt annies alligator', unitURI: @unit.pid, copyrightURI: @copy.pid)
+    @obj2 = DamsObject.create(titleValue: "\'Four fluffy feathers on a Fiffer-feffer-feff\'", unitURI: @unit.pid, copyrightURI: @copy.pid)
+    @obj3 = DamsObject.create(titleValue: "(Willies in the washtub) watching waldo woo", unitURI: @unit.pid, copyrightURI: @copy.pid)
+    @obj4 = DamsObject.create(titleValue: "\"Zizzer zazzer zuzz\"", unitURI: @unit.pid, copyrightURI: @copy.pid)
+    solr_index @obj1.pid
+    solr_index @obj2.pid
+    solr_index @obj3.pid
+    solr_index @obj4.pid
+  end
+
+  after(:all) do
+    @obj1.delete
+    @obj2.delete
+    @obj3.delete
+    @obj4.delete
+    @copy.delete
+    @unit.delete
+  end
+
+  scenario 'results sorted by title ignoring case and special characters' do
+    sign_in_developer
+    visit catalog_index_path( {'q' => '', 'per_page' => 100, 'sort' => 'title_ssi asc'} )
+    idx1 = page.body.index('aunt annies alligator')
+    idx2 = page.body.index("\'Four fluffy feathers on a Fiffer-feffer-feff\'")
+    idx3 = page.body.index("(Willies in the washtub) watching waldo woo")
+    idx4 = page.body.index("\"Zizzer zazzer zuzz\"")
+    expect([idx1,idx2,idx3,idx4].include?(nil)).to eq false
+    expect([idx1,idx2,idx3,idx4].sort).to eq([idx1,idx2,idx3,idx4])
+  end
+end
+
 feature 'Visitor wants to view icons for the objects in the search result page' do
   before(:all) do
     @unit = DamsUnit.create pid: 'xx48484848', name: "Test Unit", description: "Test Description",
@@ -505,7 +540,7 @@ feature 'Visitor wants to view object of metadata data-only visibility collectio
     ns = Rails.configuration.id_namespace
     @note = DamsNote.create type: "local attribution", value: "Digital Library Development Program, UC San Diego, La Jolla, 92093-0175"
     @localDisplay = DamsOtherRight.create permissionType: "localDisplay"
-    @localOnlyCollection = DamsProvenanceCollection.create titleValue: "Test UCSD IP only Collection with localDisplay visibility", visibility: "local"    
+    @localOnlyCollection = DamsProvenanceCollection.create titleValue: "Test UCSD IP only Collection with localDisplay visibility", visibility: "local"
     @localObj = DamsObject.create pid: 'xx909090zz', titleValue: 'Test Object with localDisplay', provenanceCollectionURI: @localOnlyCollection.pid, otherRightsURI: @localDisplay.pid, note_attributes: [{ id: RDF::URI.new("#{ns}#{@note.pid}") }], copyright_attributes: [{status: 'Public domain'}]
     solr_index @note.pid
     solr_index @localDisplay.pid
@@ -531,7 +566,7 @@ feature 'Visitor wants to view object of metadata data-only visibility collectio
     expect(page).to_not have_css('img.dams-search-thumbnail[src="https://library.ucsd.edu/assets/dams/site/thumb-restricted.png"]')
     expect(page).to have_content('Restricted to UC San Diego use only')
   end
-  
+
   scenario 'local user should not see the grey generic thumbnail and restricted access info' do
     sign_in_anonymous '132.239.0.3'
     visit catalog_index_path({:q => 'xx909090zz'})
@@ -571,7 +606,7 @@ feature 'Visitor wants to view localDisplay License object in UCSD local collect
     expect(page).to_not have_css('img.dams-search-thumbnail[src="https://library.ucsd.edu/assets/dams/site/thumb-restricted.png"]')
     expect(page).to_not have_content('Restricted View')
   end
-  
+
   scenario 'public user should see the grey generic thumbnail and restricted access info' do
     visit catalog_index_path({:q => @localObj.pid})
     expect(page).to have_css('img.dams-search-thumbnail[src="https://library.ucsd.edu/assets/dams/site/thumb-restricted.png"]')
@@ -593,7 +628,7 @@ feature 'Visitor wants to view metdatadataDisplay object for public collection i
     ns = Rails.configuration.id_namespace
     @note = DamsNote.create type: "local attribution", value: "Digital Library Development Program, UC San Diego, La Jolla, 92093-0175"
     @metadataDisplay = DamsOtherRight.create permissionType: "metadataDisplay"
-    @publicCollection = DamsProvenanceCollection.create titleValue: "Test Public Collection", visibility: "public"    
+    @publicCollection = DamsProvenanceCollection.create titleValue: "Test Public Collection", visibility: "public"
     @obj = DamsObject.create pid: 'xx909090yy', titleValue: 'Test Object with localDisplay', note_attributes: [{ id: RDF::URI.new("#{ns}#{@note.pid}") }], copyright_attributes: [{status: 'Under Copyright'}]
     @obj.otherRightsURI = @metadataDisplay.pid
     @obj.provenanceCollectionURI = @publicCollection.pid
@@ -622,7 +657,7 @@ feature 'Visitor wants to view metdatadataDisplay object for public collection i
     expect(page).to have_css('img.dams-search-thumbnail[src="https://library.ucsd.edu/assets/dams/site/thumb-restricted.png"]')
     expect(page).to have_content('Restricted View')
   end
-  
+
   scenario 'curator user should not see the grey generic thumbnail and still see restricted access info' do
     sign_in_developer
     visit catalog_index_path({:q => 'xx909090yy'})


### PR DESCRIPTION
Fixes #661 

[MERGED](https://github.com/ucsdlib/dams4-solr/pull/5) ~~NOTE: There will need to be an accompanying PR against `dams4-solr` with these `schema.xml` changes. I haven't put that up yet, because I'd like feedback from the team on this approach before doing so. This will require a full reindex, so we want to get this right the first time, ideally..~~

#### Local Checklist
- [x] Tests written and passing locally?
- [x] Code style checked?
- [x] QA-ed locally?
- [x] Rebased with `master` branch?
- [ ] Configuration updated (if needed)?
- [ ] Documentation updated (if needed)?

#### What does this PR do?
- creates an `alphaStrippedSort` `fieldtype` which ignores double quotes/single quotes, and parens (for now), and filters case-sensitivity
- explicitly declares `title_ssi` as a field of type `alphaStrippedSort` for use in
  sorting instead of the default tokenizer/filters applied when analyzing `title_ssi`
- adds a test verifying the results illustrated in the attached screenshot

##### Why are we doing this? Any context of related work?
References #661 

#### Screenshots
![pic-selected-190716-1301-44](https://user-images.githubusercontent.com/67506/61325851-6fa7a180-a7ca-11e9-974c-9de41ab3d4a8.png)

@ucsdlib/developers - please review
